### PR TITLE
Add a new attachment property for cells.

### DIFF
--- a/docs/format_description.rst
+++ b/docs/format_description.rst
@@ -295,10 +295,16 @@ regardless of format.
 
 Cell attachments
 ----------------
+.. versionadded:: 4.1
+
 Markdown and raw cells can have a number of attachments, typically inline
-images that can be referenced in the markdown content of a cell. The attachment
+images that can be referenced in the markdown content of a cell. The ``attachments``
 dictionary of a cell contains a set of mime-bundles (see :ref:`display_data`)
 keyed by filename that represents the files attached to the cell.
+
+.. note::
+
+  The ``attachments`` dictionary is an optional field and can be undefined or empty if the cell does not have any attachments.
 
 
 .. sourcecode:: python
@@ -313,6 +319,7 @@ keyed by filename that represents the files attached to the cell.
         },
       },
     }
+
 
 Backward-compatible changes
 ===========================

--- a/docs/format_description.rst
+++ b/docs/format_description.rst
@@ -66,7 +66,6 @@ All cells have the following basic structure:
       "cell_type" : "name",
       "metadata" : {},
       "source" : "single string or [list, of, strings]",
-      "attachments" : {},
     }
 
 .. note::
@@ -296,8 +295,9 @@ regardless of format.
 
 Cell attachments
 ----------------
-A cell can have a number of attachments, typically inline images that can be referenced in the markdown
-content of a cell. The attachment dictionary of a cell contains a set of mime-bundles (see :ref:`display_data`)
+Markdown and raw cells can have a number of attachments, typically inline
+images that can be referenced in the markdown content of a cell. The attachment
+dictionary of a cell contains a set of mime-bundles (see :ref:`display_data`)
 keyed by filename that represents the files attached to the cell.
 
 

--- a/docs/format_description.rst
+++ b/docs/format_description.rst
@@ -66,6 +66,7 @@ All cells have the following basic structure:
       "cell_type" : "name",
       "metadata" : {},
       "source" : "single string or [list, of, strings]",
+      "attachments" : {},
     }
 
 .. note::
@@ -155,6 +156,7 @@ stream output
     The ``stream`` key was changed to ``name`` to match
     the stream message.
 
+.. _display-data:
 
 display_data
 ************
@@ -289,6 +291,27 @@ regardless of format.
         "format" : "mime/type"
       },
       "source" : "[some nbformat output text]"
+    }
+
+
+Cell attachments
+----------------
+A cell can have a number of attachments, typically inline images that can be referenced in the markdown
+content of a cell. The attachment dictionary of a cell contains a set of mime-bundles (see :ref:`display_data`)
+keyed by filename that represents the files attached to the cell.
+
+
+.. sourcecode:: python
+
+    {
+      "cell_type" : "markdown",
+      "metadata" : {},
+      "source" : ["Here is an *inline* image ![inline image](attachment:test.png)"],
+      "attachments" : {
+        "test.png": {
+            "image/png" : ["base64-encoded-png-data"],
+        },
+      },
     }
 
 Backward-compatible changes

--- a/nbformat/v4/nbbase.py
+++ b/nbformat/v4/nbbase.py
@@ -13,7 +13,7 @@ from ..notebooknode import from_dict, NotebookNode
 
 # Change this when incrementing the nbformat version
 nbformat = 4
-nbformat_minor = 0
+nbformat_minor = 1
 nbformat_schema = 'nbformat.v4.schema.json'
 
 

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -113,6 +113,7 @@
                         "tags": {"$ref": "#/definitions/misc/metadata_tags"}
                     }
                 },
+                "attachments": {"$ref": "#/definitions/misc/attachments"},
                 "source": {"$ref": "#/definitions/misc/source"}
             }
         },
@@ -136,6 +137,7 @@
                     },
                     "additionalProperties": true
                 },
+                "attachments": {"$ref": "#/definitions/misc/attachments"},
                 "source": {"$ref": "#/definitions/misc/source"}
             }
         },
@@ -167,6 +169,7 @@
                         "tags": {"$ref": "#/definitions/misc/metadata_tags"}
                     }
                 },
+                "attachments": {"$ref": "#/definitions/misc/attachments"},
                 "source": {"$ref": "#/definitions/misc/source"},
                 "outputs": {
                     "description": "Execution, display, or stream outputs.",
@@ -201,7 +204,8 @@
                         "tags": {"$ref": "#/definitions/misc/metadata_tags"}
                     },
                     "additionalProperties": true
-                }
+                },
+                "attachments": {"$ref": "#/definitions/misc/attachments"}
             }
         },
         
@@ -325,6 +329,16 @@
                 "items": {
                     "type": "string",
                     "pattern": "^[^,]+$"
+                }
+            },
+            "attachments": {
+                "description": "Media attachments (e.g. inline images), stored as mimebundle keyed by filename.",
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "description": "The attachment's data stored as a mimebundle.",
+                        "$ref": "#/definitions/misc/mimebundle"
+                    }
                 }
             },
             "source": {

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -169,7 +169,6 @@
                         "tags": {"$ref": "#/definitions/misc/metadata_tags"}
                     }
                 },
-                "attachments": {"$ref": "#/definitions/misc/attachments"},
                 "source": {"$ref": "#/definitions/misc/source"},
                 "outputs": {
                     "description": "Execution, display, or stream outputs.",
@@ -204,8 +203,7 @@
                         "tags": {"$ref": "#/definitions/misc/metadata_tags"}
                     },
                     "additionalProperties": true
-                },
-                "attachments": {"$ref": "#/definitions/misc/attachments"}
+                }
             }
         },
         


### PR DESCRIPTION
This is a proposal to add a new 'attachments' property to cells to allow for inline medias.
The primary use case is to be able to add images to markdown cells and store them directly in the notebook (as opposed to having them on the filesystem).

References :
original issue : https://github.com/jupyter/notebook/issues/613 
corresponding notebook PR : https://github.com/jupyter/notebook/pull/621