### PR TITLE
truncate validation error messages

### DIFF
--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -55,4 +55,14 @@ class TestValidator(TestsBase):
         
         self.assertEqual(isvalid(nb, version=4), False)
         self.assertEqual(isvalid(nb), True)
-
+    
+    def test_validation_error(self):
+        with self.fopen(u'invalid.ipynb', u'r') as f:
+            nb = read(f, as_version=4)
+        with self.assertRaises(ValidationError) as e:
+            validate(nb)
+        s = str(e.exception)
+        self.assertRegexpMatches(s, "validating.*required.* in markdown_cell")
+        self.assertRegexpMatches(s, "source.* is a required property")
+        self.assertRegexpMatches(s, r"On instance\[u?['\"].*cells['\"]\]\[0\]")
+        self.assertLess(len(s.splitlines()), 10)


### PR DESCRIPTION
avoids logging entire notebooks and schemata when errors are found at the top level

nbviewer's logs contain 100s of MB of notebooks for tiny schema errors if those errors are at a high level.

What would include the entire schema and the entire notebook is now:

```
Notebook JSON is invalid: Additional properties are not allowed ('name' was unexpected)

Failed validating 'additionalProperties' in notebook:

On instance:
{'cells': ['...5 cells...'],
 'metadata': {'orig_nbformat': 3},
 'name': 'wapiti',
 'nbformat': 4,
 'nbformat_minor': 0}
```

or on a single output:

```
Notebook JSON is invalid: Additional properties are not allowed ('key' was unexpected)

Failed validating 'additionalProperties' in stream:

On instance['cells'][3]['outputs'][0]:
{'key': 'bad', 'name': 'stdout', 'output_type': 'stream', 'text': 'hello\n'}
```