### PR TITLE
store notebook signatures in runtime_dir by default

### DIFF
--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -15,11 +15,11 @@ from nbformat import read, sign
 class TestNotary(TestsBase):
     
     def setUp(self):
-        self.data_dir = tempfile.mkdtemp()
+        self.secret_dir = tempfile.mkdtemp()
         self.notary = sign.NotebookNotary(
             db_file=':memory:',
             secret=b'secret',
-            data_dir=self.data_dir,
+            secret_dir=self.secret_dir,
         )
         with self.fopen(u'test3.ipynb', u'r') as f:
             self.nb = read(f, as_version=4)
@@ -27,7 +27,7 @@ class TestNotary(TestsBase):
             self.nb3 = read(f, as_version=3)
     
     def tearDown(self):
-        shutil.rmtree(self.data_dir)
+        shutil.rmtree(self.secret_dir)
     
     def test_algorithms(self):
         last_sig = ''


### PR DESCRIPTION
This is what the docstring described, but not what we did. Include deprecation of data_dir. If files are found in the old location and not in the new one, a warning is shown and the files are **copied** to the new location.

Rename trait where secrets are stored to `secret_dir`, with deprecated alias for `data_dir`.

closes #29