### PR TITLE
Issue 26: Check and handle errors loading signature db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: false
 env:
 install:
     - pip install . coveralls
+    - pip install nbformat[test]
 script:
     - nosetests --with-coverage --cover-package=nbformat nbformat
 after_success:

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -4,9 +4,11 @@
 # Distributed under the terms of the Modified BSD License.
 
 import copy
+import os
 import shutil
 import time
 import tempfile
+import testpath
 
 from .base import TestsBase
 
@@ -28,6 +30,20 @@ class TestNotary(TestsBase):
     
     def tearDown(self):
         shutil.rmtree(self.data_dir)
+   
+    def test_invalid_db_file(self):
+        invalid_sql_file = os.path.join(self.data_dir, 'invalid_db_file.db')
+        with open(invalid_sql_file, 'w') as tempfile:
+            tempfile.write(u'[invalid data]')
+
+        invalid_notary = sign.NotebookNotary(
+            db_file=invalid_sql_file,
+            secret=b'secret',
+        )
+        invalid_notary.sign(self.nb)
+
+        testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file))
+        testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file + '.bak'))
     
     def test_algorithms(self):
         last_sig = ''
@@ -191,5 +207,4 @@ class TestNotary(TestsBase):
         self.assertFalse(self.notary.check_cells(nb))
         for cell in cells:
             self.assertNotIn('trusted', cell)
-        
 

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
+    'test': ['testpath'],
 }
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
- A potential fix for issue #26 which will also address ipython issue 9003.  
- Cannot seem to get the tests to load the invalid db file I've created - any suggestions?  