### PR TITLE
Raise jsonschema dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'ipython_genutils',
     'traitlets',
-    'jsonschema>=2.0,!=2.5.0',
+    'jsonschema>=2.4,!=2.5.0',
     'jupyter_core',
 ]
 


### PR DESCRIPTION
Executing the tests with jsonschema-2.3.0 installed the tests fail with:

```
======================================================================
ERROR: test_validation_error (nbformat.tests.test_validator.TestValidator)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/tmp/portage/dev-python/nbformat-4.1.0/work/nbformat-4.1.0/nbformat/tests/test_validator.py", line 61, in test_validation_error
    nb = read(f, as_version=4)
  File "/var/tmp/portage/dev-python/nbformat-4.1.0/work/nbformat-4.1.0/nbformat/__init__.py", line 141, in read
    return reads(fp.read(), as_version, **kwargs)
  File "/var/tmp/portage/dev-python/nbformat-4.1.0/work/nbformat-4.1.0/nbformat/__init__.py", line 78, in reads
    validate(nb)
  File "/var/tmp/portage/dev-python/nbformat-4.1.0/work/nbformat-4.1.0/nbformat/validator.py", line 242, in validate
    raise better_validation_error(e, version, version_minor)
  File "/var/tmp/portage/dev-python/nbformat-4.1.0/work/nbformat-4.1.0/nbformat/validator.py", line 206, in better_validation_error
    error.relative_path.extend(sub_error.relative_path)
AttributeError: 'ValidationError' object has no attribute 'relative_path'
```

`ValidationError` is imported from `jsonschema`. Installing version 2.4.0, the issue is resolved.