### PR TITLE
Allow custom mimetypes with +json suffix

### DIFF
--- a/nbformat/tests/test4custom.ipynb
+++ b/nbformat/tests/test4custom.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.raw.v1+json": {
+       "apples": [
+        "🍎",
+        "🍏"
+       ],
+       "bananas": 2,
+       "oranges": "apples"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import IPython\n",
+    "\n",
+    "bundle = {}\n",
+    "bundle['application/vnd.raw.v1+json'] = {\n",
+    "    'apples': ['🍎', '🍏'],\n",
+    "    'bananas': 2,\n",
+    "    'oranges': 'apples'\n",
+    "}\n",
+    "\n",
+    "IPython.display.display(bundle, raw=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -34,6 +34,13 @@ class TestValidator(TestsBase):
         validate(nb)
         self.assertEqual(isvalid(nb), True)
 
+    def test_nb4custom(self):
+        """Test that a notebook with a custom JSON mimetype passes validation"""
+        with self.fopen(u'test4custom.ipynb', u'r') as f:
+            nb = read(f, as_version=4)
+        validate(nb)
+        self.assertEqual(isvalid(nb), True)
+
     def test_invalid(self):
         """Test than an invalid notebook does not pass validation"""
         # this notebook has a few different errors:
@@ -52,10 +59,10 @@ class TestValidator(TestsBase):
             nb = read(f, as_version=4)
         with self.assertRaises(ValidationError):
             validate(nb, version=4)
-        
+
         self.assertEqual(isvalid(nb, version=4), False)
         self.assertEqual(isvalid(nb), True)
-    
+
     def test_validation_error(self):
         with self.fopen(u'invalid.ipynb', u'r') as f:
             nb = read(f, as_version=4)

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -351,16 +351,14 @@
             "mimebundle": {
                 "description": "A mime-type keyed dictionary of data",
                 "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "application/json": {
-                        "type": "object"
-                    }
+                "additionalProperties": {
+                  "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
+                  "$ref": "#/definitions/misc/multiline_string"
                 },
                 "patternProperties": {
-                    "^(?!application/json$)[a-zA-Z0-9]+/[a-zA-Z0-9\\-\\+\\.]+$": {
-                        "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
-                        "$ref": "#/definitions/misc/multiline_string"
+                    "^application/([a-zA-Z0-9.]+\\+)?json$": {
+                        "description": "Mimetypes with JSON output, can be an object",
+                        "type": "object"
                     }
                 }
             },


### PR DESCRIPTION
Closes #42.

Otherwise plain JSON objects will make the notebook displeased. Currently if a mime type like this comes across on the message spec, all is fine up until the notebook is saved. nbviewer and nteract handle it fine, jupyter notebook does not:

![output complaints from jupyter notebook](https://cloud.githubusercontent.com/assets/1280389/18218499/077c8828-7131-11e6-9e05-5d0456be124c.png)