### PR TITLE
[WIP] support dbapi providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__
 \#*#
 .#*
 .coverage
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,22 @@ python:
     - 3.3
     - 2.7
 sudo: false
-env:
+services:
+  - postgres
 install:
-    - pip install . codecov
-    - pip install nbformat[test]
+  - pip install . codecov
+  - pip install nbformat[test]
+  - |
+    if [[ ! -z "$NBFORMAT_TEST_POSTGRES" ]]; then
+      psql -c 'create database travis_ci_test;' -U postgres
+      pip install psycopg2
+      cp ci/postgres_jupyter_config.py ./jupyter_config.py
+    fi
 script:
-    - nosetests --with-coverage --cover-package=nbformat nbformat
+  - nosetests --with-coverage --cover-package=nbformat nbformat
 after_success:
-    - codecov
+  - codecov
+matrix:
+  include:
+    - env: NBFORMAT_TEST_POSTGRES=1
+      python: 3.5

--- a/ci/postgres_jupyter_config.py
+++ b/ci/postgres_jupyter_config.py
@@ -1,0 +1,5 @@
+# config file for running Travis with postgres
+c.NotebookNotary.db_connect = 'psycopg2.connect'
+c.NotebookNotary.db_connect_kwargs = dict(
+    database='travis_ci_test',
+)


### PR DESCRIPTION
allows storing the test data in postgres via psycopg2.

Even the n=2 case of sqlite and psycopg2 have a lot less in common than I'd like,
so maybe we shouldn't do this and go with sqlalchemy instead.

I thought that dbapi provided some minimal common API, but really the only thing they have in common is a few method names (not even their signatures or argument-formatting conventions are common).

The WIP bit is for actually triggering the tests on Travis, which don't yet run the tests with postgres.
