### PR TITLE
allow trusting a notebook from stdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__
 \#*#
 .#*
 .coverage
+.cache

--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -10,6 +10,7 @@ import hashlib
 from hmac import HMAC
 import io
 import os
+import sys
 
 try:
     import sqlite3
@@ -19,12 +20,12 @@ except ImportError:
     except ImportError:
         sqlite3 = None
 
-from ipython_genutils.py3compat import unicode_type, cast_bytes
+from ipython_genutils.py3compat import unicode_type, cast_bytes, cast_unicode
 from traitlets import Instance, Bytes, Enum, Any, Unicode, Bool, Integer
 from traitlets.config import LoggingConfigurable, MultipleInstanceError
 from jupyter_core.application import JupyterApp, base_flags
 
-from . import read, NO_CONVERT, __version__
+from . import read, reads, NO_CONVERT, __version__
 
 try:
     # Python 3
@@ -401,12 +402,17 @@ class TrustNotebookApp(JupyterApp):
     def _notary_default(self):
         return NotebookNotary(parent=self, data_dir=self.data_dir)
     
-    def sign_notebook(self, notebook_path):
+    def sign_notebook_file(self, notebook_path):
+        """Sign a notebook from the filesystem"""
         if not os.path.exists(notebook_path):
             self.log.error("Notebook missing: %s" % notebook_path)
             self.exit(1)
         with io.open(notebook_path, encoding='utf8') as f:
             nb = read(f, NO_CONVERT)
+        self.sign_notebook(nb, notebook_path)
+    
+    def sign_notebook(self, nb, notebook_path='<stdin>'):
+        """Sign a notebook that's been loaded"""
         if self.notary.check_signature(nb):
             print("Notebook already signed: %s" % notebook_path)
         else:
@@ -426,9 +432,16 @@ class TrustNotebookApp(JupyterApp):
             self.generate_new_key()
             return
         if not self.extra_args:
-            self.log.critical("Specify at least one notebook to sign.")
-            self.exit(1)
-        
-        for notebook_path in self.extra_args:
-            self.sign_notebook(notebook_path)
+            self.log.debug("Reading notebook from stdin")
+            nb_s = cast_unicode(sys.stdin.read())
+            nb = reads(nb_s, NO_CONVERT)
+            self.sign_notebook(nb, '<stdin>')
+        else:
+            for notebook_path in self.extra_args:
+                self.sign_notebook_file(notebook_path)
 
+
+main = TrustNotebookApp.launch_instance
+
+if __name__ == '__main__':
+    main()

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -3,8 +3,8 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import codecs
 import copy
-from io import TextIOWrapper
 import os
 import shutil
 from subprocess import Popen, PIPE
@@ -218,7 +218,8 @@ class TestNotary(TestsBase):
             p = Popen([sys.executable, '-m', 'nbformat.sign', '--log-level=0'], stdin=PIPE, stdout=PIPE,
                 env=env,
             )
-            write(nb, TextIOWrapper(p.stdin, encoding='utf8'))
+            write(nb, codecs.getwriter("utf8")(p.stdin))
+            p.stdin.close()
             p.wait()
             self.assertEqual(p.returncode, 0)
             return p.stdout.read().decode('utf8', 'replace')

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -4,15 +4,18 @@
 # Distributed under the terms of the Modified BSD License.
 
 import copy
+from io import TextIOWrapper
 import os
 import shutil
+from subprocess import Popen, PIPE
+import sys
 import time
 import tempfile
 import testpath
 
 from .base import TestsBase
 
-from nbformat import read, sign
+from nbformat import read, sign, write
 
 class TestNotary(TestsBase):
     
@@ -207,4 +210,20 @@ class TestNotary(TestsBase):
         self.assertFalse(self.notary.check_cells(nb))
         for cell in cells:
             self.assertNotIn('trusted', cell)
+    
+    def test_sign_stdin(self):
+        def sign_stdin(nb):
+            env = os.environ.copy()
+            env["JUPYTER_DATA_DIR"] = self.data_dir
+            p = Popen([sys.executable, '-m', 'nbformat.sign', '--log-level=0'], stdin=PIPE, stdout=PIPE,
+                env=env,
+            )
+            write(nb, TextIOWrapper(p.stdin, encoding='utf8'))
+            p.wait()
+            self.assertEqual(p.returncode, 0)
+            return p.stdout.read().decode('utf8', 'replace')
 
+        out = sign_stdin(self.nb3)
+        self.assertIn('Signing notebook: <stdin>', out)
+        out = sign_stdin(self.nb3)
+        self.assertIn('already signed: <stdin>', out)


### PR DESCRIPTION
enables `cat notebook | jupyter trust`

closes #27