### PR TITLE
Draft spec for capturing a notebook environment

### DIFF
--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -77,24 +77,37 @@
                       "additionalProperties": true
                     }
                 },
-                "environment": {
-                    "description": "Specification of an environment in which this notebook was authored and executed",
-                    "type": "object",
-                    "anyOf": [
-                        {"required": ["type", "source"]},
-                        {"required": ["type", "spec"]}
-                    ],
-                    "properties": {
-                        "type": {
-                            "description": "The type of environment specification, preferably a mimetype including a version number (e.g., application/vnd.docker.dockerfile.v1)",
-                            "type": "string"
-                        },
-                        "source": {
-                            "description": "URI of the environment specification stored external to the notebook document",
-                            "type": "string"
-                        },
-                        "spec": {
-                            "description": "Environment specification stored internally in the notebook document"
+                "environments": {
+                    "description": "Collection of environments in which this notebook was authored and executed",
+                    "type": "array",
+                    "item": {
+                        "description": "Specification of an environment in which this notebook was authored and executed",
+                        "type": "object",
+                        "anyOf": [
+                            {"required": ["type", "source"]},
+                            {"required": ["type", "spec"]}
+                        ],
+                        "properties": {
+                            "type": {
+                                "description": "The type of environment specification, preferably a mimetype including a version number (e.g., application/vnd.docker.dockerfile.v1)",
+                                "type": "string"
+                            },
+                            "source": {
+                                "description": "URI of the environment specification stored external to the notebook document",
+                                "type": "string"
+                            },
+                            "spec": {
+                                "description": "Environment specification stored internally in the notebook document"
+                            },
+                            "specifier": {
+                                "description": "Name of the package, library, tool, human, etc. that created this specification. Primarily for advisory purposes",
+                                "type": "string"
+                            },
+                            "extra": {
+                                "description": "A place for the specifier to store additional information about the environment that cannot be captured in a valid way in the specification itself (e.g., pip index URLs)",
+                                "type": "object",
+                                "additionalProperties": true
+                            }
                         }
                     }
                 }

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -93,18 +93,18 @@
                                 "type": "string"
                             },
                             "source": {
-                                "description": "URI of the environment specification stored external to the notebook document",
+                                "description": "URI of an environment specification in the format defined by 'type', stored external to the notebook document. Mutually exclusive with spec.",
                                 "type": "string"
                             },
                             "spec": {
-                                "description": "Environment specification stored internally in the notebook document"
+                                "description": "Environment specification in the format defined by 'type', stored within the notebook document itself. Mutually exclusive with source."
                             },
-                            "specifier": {
-                                "description": "Name of the package, library, tool, human, etc. that created this specification. Primarily for advisory purposes",
+                            "generator": {
+                                "description": "Name of the package, library, tool, human, etc. that inserted this environment metadata into this notebook (e.g., some-jupyter-environments-extension, Jane Doe, conda-environment-grabber). Primarily for advisory purposes, such as where to file bug reports.",
                                 "type": "string"
                             },
                             "extra": {
-                                "description": "A place for the specifier to store additional information about the environment that cannot be captured in a valid way in the specification itself (e.g., pip index URLs)",
+                                "description": "A place for the specifier to store arbitrary additional information about the environment that cannot be captured in a valid way inside the environment specification format itself (e.g., pip index URLs). Allowed in combination with either the 'spec' or 'source' fields.",
                                 "type": "object",
                                 "additionalProperties": true
                             }

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -76,6 +76,27 @@
                       },
                       "additionalProperties": true
                     }
+                },
+                "environment": {
+                    "description": "Specification of an environment in which this notebook was authored and executed",
+                    "type": "object",
+                    "anyOf": [
+                        {"required": ["type", "source"]},
+                        {"required": ["type", "spec"]}
+                    ],
+                    "properties": {
+                        "type": {
+                            "description": "The type of environment specification, preferably a mimetype including a version number (e.g., application/vnd.docker.dockerfile.v1)",
+                            "type": "string"
+                        },
+                        "source": {
+                            "description": "URI of the environment specification stored external to the notebook document",
+                            "type": "string"
+                        },
+                        "spec": {
+                            "description": "Environment specification stored internally in the notebook document"
+                        }
+                    }
                 }
             }
         },

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -104,7 +104,7 @@
                                 "type": "string"
                             },
                             "extra": {
-                                "description": "A place for the specifier to store arbitrary additional information about the environment that cannot be captured in a valid way inside the environment specification format itself (e.g., pip index URLs). Allowed in combination with either the 'spec' or 'source' fields.",
+                                "description": "A place for the generator to store arbitrary additional information about the environment that cannot be captured in a valid way inside the environment specification format itself (e.g., pip index URLs). Allowed in combination with either the 'spec' or 'source' fields.",
                                 "type": "object",
                                 "additionalProperties": true
                             }


### PR DESCRIPTION
Continuing the conversation started in #49 with a concrete schema change for us to consider. For now, I left the `type` loose with a suggestion that it be a mimetype including a version that we could capture elsewhere (https://github.com/jupyter/jupyter/blob/master/docs/source/reference/mimetype.md).

@rgbkrk, would you prefer an explicit version field instead? I felt like having it as a peer of type and spec suggested it was the version of the environment itself, not the environment spec format.

One thought I had along the way. Does environment(s) need to be an array? Do we need to worry about conda environments in docker containers? Or about notebooks that can run in a particular conda environment OR a particular virtualenv? I'd like to keep it simple and say the notebook captures *the* environment in which it was authored rather than all environments in which it can run, but maybe someone has a compelling use case for N rather than 1 environment.