### PR TITLE
Convert notebook signatures database to use hash filenames

### DIFF
--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -98,8 +98,7 @@ class FilenamesHashSet(object):
         self.directory = directory
 
     def _dir_and_file(self, hexdigest):
-        dir_parts = hexdigest[0:2], hexdigest[2:4]
-        return os.path.join(self.directory, *dir_parts), hexdigest[4:]
+        return os.path.join(self.directory, hexdigest[0:2]), hexdigest[2:]
 
     def add(self, hexdigest):
         """Add a hash to the set if it's not already present."""
@@ -175,7 +174,7 @@ class NotebookNotary(LoggingConfigurable):
             return ':memory:'
         return os.path.join(self.data_dir, u'nbsignatures.db')
 
-    cache_size = Integer(256**3,
+    cache_size = Integer(256**2,
         help="""The number of notebook signatures to cache.
         When the number of signatures exceeds this value,
         the oldest 25% of signatures will be culled.

--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -5,12 +5,15 @@
 
 import base64
 from contextlib import contextmanager
-from datetime import datetime
 import hashlib
 from hmac import HMAC
 import io
 import os
 import sys
+import time
+import warnings
+
+import errno
 
 try:
     import sqlite3
@@ -90,8 +93,57 @@ def signature_removed(nb):
             nb['metadata']['signature'] = save_signature
 
 
+class FilenamesHashSet(object):
+    def __init__(self, directory):
+        self.directory = directory
+
+    def _dir_and_file(self, hexdigest):
+        dir_parts = hexdigest[0:2], hexdigest[2:4]
+        return os.path.join(self.directory, *dir_parts), hexdigest[4:]
+
+    def add(self, hexdigest):
+        """Add a hash to the set if it's not already present."""
+        dir, file_name = self._dir_and_file(hexdigest)
+        try:
+            os.makedirs(dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
+        with open(os.path.join(dir, file_name), 'wb'): pass
+
+    def discard(self, hexdigest):
+        """Discard a hash from the set; ignore if it's not included."""
+        dir, file_name = self._dir_and_file(hexdigest)
+        try:
+            os.unlink(os.path.join(dir, file_name))
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+    def __contains__(self, hexdigest):
+        dir, file_name = self._dir_and_file(hexdigest)
+        return os.path.isfile(os.path.join(dir, file_name))
+
+    def check_and_update(self, hexdigest):
+        """If a hash is in the set, return True and update its mtime."""
+        dir, file_name = self._dir_and_file(hexdigest)
+        if os.path.isfile(os.path.join(dir, file_name)):
+            os.utime(os.path.join(dir, file_name), None)
+            return True
+        return False
+
+
 class NotebookNotary(LoggingConfigurable):
     """A class for computing and verifying notebook signatures."""
+
+    def __init__(self, **kwargs):
+        super(NotebookNotary, self).__init__(**kwargs)
+        d = os.path.join(self.data_dir, self.algorithm+'_hashes')
+        self.hash_store = FilenamesHashSet(d)
+
+        self.migrate_sqlite_to_filenames()
+        self.cull_db()
     
     data_dir = Unicode()
     @default('data_dir')
@@ -107,11 +159,14 @@ class NotebookNotary(LoggingConfigurable):
             app = JupyterApp()
             app.initialize(argv=[])
         return app.data_dir
+
+    @property
+    def cull_marker(self):
+        return os.path.join(self.data_dir, 'signatures_cull_time_marker')
     
     db_file = Unicode(
-        help="""The sqlite file in which to store notebook signatures.
-        By default, this will be in your Jupyter data directory.
-        You can set it to ':memory:' to disable sqlite writing to the filesystem.
+        help="""DEPRECATED: Path to an SQLite file to store notebook signatures.
+        The signature mechanism no longer uses SQLite.
         """).tag(config=True)
 
     @default('db_file')
@@ -119,17 +174,21 @@ class NotebookNotary(LoggingConfigurable):
         if not self.data_dir:
             return ':memory:'
         return os.path.join(self.data_dir, u'nbsignatures.db')
-    
-    # 64k entries ~ 12MB
-    cache_size = Integer(65535,
+
+    cache_size = Integer(256**3,
         help="""The number of notebook signatures to cache.
         When the number of signatures exceeds this value,
         the oldest 25% of signatures will be culled.
         """
     ).tag(config=True)
-    db = Any()
-    @default('db')
-    def _db_default(self):
+
+    cull_interval = Integer(60 * 60 * 24 * 30,
+        help="""Time in seconds to wait before culling old signatures.
+        The default is 30 days.
+        """
+    ).tag(config=True)
+
+    def _connect_sqlite_database(self):
         if sqlite3 is None:
             self.log.warn("Missing SQLite3, all notebooks will be untrusted!")
             return
@@ -138,23 +197,9 @@ class NotebookNotary(LoggingConfigurable):
             db = sqlite3.connect(self.db_file, **kwargs)
             self.init_db(db)
         except (sqlite3.DatabaseError, sqlite3.OperationalError):
-            if self.db_file != ':memory:':
-                old_db_location = os.path.join(self.data_dir, self.db_file + ".bak")
-                self.log.warn("""The signatures database cannot be opened; maybe it is corrupted or encrypted.  You may need to rerun your notebooks to ensure that they are trusted to run Javascript.  The old signatures database has been renamed to %s and a new one has been created.""",
-                    old_db_location)
-                try:
-                    os.rename(self.db_file, self.db_file + u'.bak')
-                    db = sqlite3.connect(self.db_file, **kwargs)
-                    self.init_db(db)
-                except (sqlite3.DatabaseError, sqlite3.OperationalError):
-                    self.log.warn("""Failed commiting signatures database to disk.  You may need to move the database file to a non-networked file system, using config option `NotebookNotary.db_file`.  Using in-memory signatures database for the remainder of this session.""")
-                    self.db_file = ':memory:'
-                    db = sqlite3.connect(self.db_file, **kwargs)
-                    self.init_db(db)
-            else:
-                raise
+            return None
         return db
-    
+
     def init_db(self, db):
         db.execute("""
         CREATE TABLE IF NOT EXISTS nbsignatures
@@ -249,23 +294,9 @@ class NotebookNotary(LoggingConfigurable):
         """
         if nb.nbformat < 3:
             return False
-        if self.db is None:
-            return False
         signature = self.compute_signature(nb)
-        r = self.db.execute("""SELECT id FROM nbsignatures WHERE
-            algorithm = ? AND
-            signature = ?;
-            """, (self.algorithm, signature)).fetchone()
-        if r is None:
-            return False
-        self.db.execute("""UPDATE nbsignatures SET last_seen = ? WHERE
-            algorithm = ? AND
-            signature = ?;
-            """,
-            (datetime.utcnow(), self.algorithm, signature),
-        )
-        self.db.commit()
-        return True
+
+        return self.hash_store.check_and_update(signature)
     
     def sign(self, nb):
         """Sign a notebook, indicating that its output is trusted on this machine
@@ -278,22 +309,7 @@ class NotebookNotary(LoggingConfigurable):
         self.store_signature(signature, nb)
 
     def store_signature(self, signature, nb):
-        if self.db is None:
-            return
-        self.db.execute("""INSERT OR IGNORE INTO nbsignatures
-            (algorithm, signature, last_seen) VALUES (?, ?, ?)""",
-            (self.algorithm, signature, datetime.utcnow())
-        )
-        self.db.execute("""UPDATE nbsignatures SET last_seen = ? WHERE
-            algorithm = ? AND
-            signature = ?;
-            """,
-            (datetime.utcnow(), self.algorithm, signature),
-        )
-        self.db.commit()
-        n, = self.db.execute("SELECT Count(*) FROM nbsignatures").fetchone()
-        if n > self.cache_size:
-            self.cull_db()
+        self.hash_store.add(signature)
     
     def unsign(self, nb):
         """Ensure that a notebook is untrusted
@@ -301,20 +317,44 @@ class NotebookNotary(LoggingConfigurable):
         by removing its signature from the trusted database, if present.
         """
         signature = self.compute_signature(nb)
-        self.db.execute("""DELETE FROM nbsignatures WHERE
-                algorithm = ? AND
-                signature = ?;
-            """,
-            (self.algorithm, signature)
-        )
-        self.db.commit()
-    
+        self.hash_store.discard(signature)
+
     def cull_db(self):
-        """Cull oldest 25% of the trusted signatures when the size limit is reached"""
-        self.db.execute("""DELETE FROM nbsignatures WHERE id IN (
-            SELECT id FROM nbsignatures ORDER BY last_seen DESC LIMIT -1 OFFSET ?
-        );
-        """, (max(int(0.75 * self.cache_size), 1),))
+        try:
+            last_cull = os.path.getmtime(self.cull_marker)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                # Create the cull marker, don't do any cull now
+                with open(self.cull_marker, 'wb'): pass
+                return
+            else:
+                raise
+
+        if time.time() - last_cull < self.cull_interval:
+            # Wait until a month has elapsed since we last considered culling.
+            return
+
+        self.log.info('Counting notebook signature hashes to decide on cull...')
+        hash_files = []
+        for dirpath, dirnames, filenames in os.walk(self.hash_store.directory):
+            for f in filenames:
+                full_path = os.path.join(dirpath, f)
+                hash_files.append(full_path)
+
+        if len(hash_files) > self.cache_size:
+            self.log.info('Culling notebook signature hashes...')
+            mtimes_files = []
+            for path in hash_files:
+                mtimes_files.append((os.path.getmtime(path), path))
+            mtimes_files.sort()
+            n_cull = len(mtimes_files) // 4
+            for _, path in mtimes_files[:n_cull]:
+                os.unlink(path)
+
+        # Update the mtime on the cull marker, so we don't check again for
+        # another month
+        os.utime(self.cull_marker, None)
+
     
     def mark_cells(self, nb, trusted):
         """Mark cells as trusted if the notebook's signature can be verified
@@ -379,6 +419,30 @@ class NotebookNotary(LoggingConfigurable):
                 trusted = False
 
         return trusted
+
+    def migrate_sqlite_to_filenames(self):
+        marker_file = os.path.join(self.data_dir, 'signatures_migrated_from_sqlite')
+        if os.path.isfile(marker_file):
+            # Skip if the marker already exists
+            return
+
+        db = None
+        if os.path.isfile(self.db_file):
+            db = self._connect_sqlite_database()
+        if db is None:
+            # Skip if the sqlite database doesn't exist or can't be read
+            with open(marker_file, 'wb'): pass
+            return
+
+        self.log.info('Migrating sqlite signatures database to filenames...')
+        cur = db.execute("SELECT signature FROM nbsignatures WHERE algorithm = ?",
+                         (self.algorithm,))
+        for signature, in cur:
+            self.store_signature(signature, None)
+
+        # Create the marker file to say that migration is complete
+        with open(marker_file, 'wb'):
+            pass
 
 
 trust_flags = {


### PR DESCRIPTION
This is a possible workaround for our SQLite issues on NFS, as discussed on jupyter/notebook#1782. The gist is that we store the signatures as filenames in hex-digest format, e.g.:

```
~/.local/share/jupyter/sha256_hashes/8d/b4/
d81e5f76570358c2d8b023e620935fe08bcc1c9a35427939227eb6ce52bd
```

So adding a signature involves ensuring the directories exist and touching the relevant file, and checking for a signature is basically just `os.path.exists(...)`. With two levels of directories at the start of the hash and 256 files as a reasonable number in each directory, there would be `256**3` files, or > 16 million. Another directory level would give > 4 billion.

Existing signatures from SQLite are migrated to this format when you first use it.

Culling is trickier with this scheme than with SQL. After discussion with Min, I have implemented it as:

- Check on instantiation, rather than on adding each hash
- Check whether a month has elapsed since the last cull, using the mtime of a marker file.
- Count the hash files using `os.path.walk`. If there are `< 256**3`, no need to cull.
- If we do need to cull, get the mtime of every hash file, and delete the oldest 25%. This is likely to be the slow bit. See below for other ideas.

Questions/concerns:

1. Is this a reasonable thing to do at all? We're trying to avoid having thousands of files in a single directory, because that's known to cause problems, but we're still creating potentially millions of files in the same filesystem. Is that going to cause problems?
2. We're trying to make one solution that works reasonably in all cases, so people can start the notebook without needing to think about this. Should instead provide a range of options for storing signatures, and accept that we'll have to keep telling users on NFS to set up a database server and switch the signature store to use that?
3. If we do proceed with this, can we come up with a more efficient way to do the cull? @Carreau and I thought about creating date-based folders with symlinks to the main hash store, so you'd have e.g. `sha256_hashes_dates/2016-11-14/8db4d81e... -> sha256_hashes/8d/b4/d81e...`. This would let you cull without reading every mtime - instead you take the oldest day, dereference those links, and delete the relevant files. I can't think of an efficient way to do this with last-seen, however. And it's extra storage and complexity.