### PR TITLE
Allow top-level arrays for "application/*json" mime type

### DIFF
--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -374,8 +374,7 @@
                 },
                 "patternProperties": {
                     "^application/([a-zA-Z0-9.]+\\+)?json$": {
-                        "description": "Mimetypes with JSON output, can be an object",
-                        "type": "object"
+                        "description": "Mimetypes with JSON output, can be any type"
                     }
                 }
             },


### PR DESCRIPTION
Closes https://github.com/jupyter/nbformat/issues/57