### PR TITLE
Update description with Jupyter name

### DIFF
--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "IPython Notebook v4.0 JSON schema.",
+    "description": "Jupyter Notebook v4.0 JSON schema.",
     "type": "object",
     "additionalProperties": false,
     "required": ["metadata", "nbformat_minor", "nbformat", "cells"],


### PR DESCRIPTION
Spec remains the same - this updates the description of the notebook format to be the _Jupyter_ notebook format.