### PR TITLE
exercise attachments, json outputs in v4 tests

### DIFF
--- a/nbformat/v4/convert.py
+++ b/nbformat/v4/convert.py
@@ -128,6 +128,7 @@ def downgrade_cell(cell):
             cell.cell_type = 'heading'
             cell.source = text
             cell.level = len(prefix)
+    cell.pop('attachments', None)
     return cell
 
 _mime_map = {
@@ -150,10 +151,11 @@ def to_mime_key(d):
 
 def from_mime_key(d):
     """convert dict with mime-type keys to v3 aliases"""
+    d2 = {}
     for alias, mime in _mime_map.items():
         if mime in d:
-            d[alias] = d.pop(mime)
-    return d
+            d2[alias] = d[mime]
+    return d2
 
 def upgrade_output(output):
     """upgrade a single code cell output from v3 to v4
@@ -209,7 +211,7 @@ def downgrade_output(output):
         data = output.pop('data', {})
         if 'application/json' in data:
             data['application/json'] = json.dumps(data['application/json'])
-        from_mime_key(data)
+        data = from_mime_key(data)
         output.update(data)
         from_mime_key(output.get('metadata', {}))
     elif output['output_type'] == 'error':

--- a/nbformat/v4/nbbase.py
+++ b/nbformat/v4/nbbase.py
@@ -13,7 +13,7 @@ from ..notebooknode import from_dict, NotebookNode
 
 # Change this when incrementing the nbformat version
 nbformat = 4
-nbformat_minor = 1
+nbformat_minor = 2
 nbformat_schema = 'nbformat.v4.schema.json'
 
 

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "Jupyter Notebook v4.0 JSON schema.",
+    "description": "Jupyter Notebook v4.2 JSON schema.",
     "type": "object",
     "additionalProperties": false,
     "required": ["metadata", "nbformat_minor", "nbformat", "cells"],

--- a/nbformat/v4/tests/nbexamples.py
+++ b/nbformat/v4/tests/nbexamples.py
@@ -24,7 +24,13 @@ cells.append(new_code_cell(
 ))
 
 cells.append(new_markdown_cell(
-    source='A random array',
+    source='Cell with attachments',
+    attachments={
+        'attachment1': {
+            'text/plain': '\n'.join(['a', 'b', 'c']),
+            'application/vnd.stuff+json': ['a', 1, 'x'],
+        }
+    }
 ))
 
 cells.append(new_raw_cell(
@@ -46,6 +52,31 @@ cells.append(new_code_cell(
 cells.append(new_code_cell(
     source='a = 10\nb = 5',
     execution_count=4,
+))
+
+cells.append(new_code_cell(
+    source=u'json_outputs()',
+    execution_count=12,
+    outputs=[new_output(
+        output_type=u'display_data',
+        data={
+            'text/plain': u'<json outputs>',
+            'application/json': {
+                'key': 'value',
+                'x': 5,
+                'lis': [1, 2, 'x']
+            },
+            'application/vnd.listofstr+json': ['a', 'b', 'c'],
+            'application/vnd.numbers+json': [1, 2, 3],
+            'application/vnd.number+json': 42,
+            'application/vnd.object+json': {
+                'number': 5,
+                'array': [1,2],
+                'str': 'x'
+            },
+            'application/vnd.string+json': 'ok',
+        },
+    )]
 ))
 
 cells.append(new_code_cell(


### PR DESCRIPTION
required some tweaks to split_lines, downgrade 4->3

downgrade 4->3:

- pop output mimes not supported on v3
- pop attachments

split_lines:

- apply split/rejoin to attachments
- avoid rejoining json arrays (related to #62)