### PR TITLE
Allow `-` in JSON-like mime types

### DIFF
--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -373,7 +373,7 @@
                   "$ref": "#/definitions/misc/multiline_string"
                 },
                 "patternProperties": {
-                    "^application/([a-zA-Z0-9.]+\\+)?json$": {
+                    "^application/(.*\\+)?json$": {
                         "description": "Mimetypes with JSON output, can be any type"
                     }
                 }


### PR DESCRIPTION
This allows dashes in `application/*+json` mime types. See https://github.com/frictionlessdata/specs/issues/289 for discussion proposing a mime type with dashes.