### PR TITLE
Pluggable signature storage

### DIFF
--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -44,7 +44,10 @@ except AttributeError:
 class SignatureStore(object):
     """Base class for a signature store."""
     def store_signature(self, digest, algorithm):
-        """Implement in subclass to store a signature."""
+        """Implement in subclass to store a signature.
+
+        Should not raise if the signature is already stored.
+        """
         raise NotImplementedError
 
     def check_signature(self, digest, algorithm):
@@ -80,6 +83,8 @@ class MemorySignatureStore(SignatureStore):
         self._maybe_cull()
 
     def _maybe_cull(self):
+        """If more than cache_size signatures are stored, delete the oldest 25%
+        """
         if len(self.data) < self.cache_size:
             return
 
@@ -212,8 +217,6 @@ class SQLiteSignatureStore(SignatureStore, LoggingConfigurable):
             SELECT id FROM nbsignatures ORDER BY last_seen DESC LIMIT -1 OFFSET ?
         );
         """, (max(int(0.75 * self.cache_size), 1),))
-
-
 
 
 def yield_everything(obj):

--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from ipython_genutils.py3compat import unicode_type, cast_bytes, cast_unicode
 from traitlets import (
-    Instance, Bytes, Enum, Any, Unicode, Bool, Integer, Callable,
+    Instance, Bytes, Enum, Any, Unicode, Bool, Integer, TraitType,
     default, observe,
 )
 from traitlets.config import LoggingConfigurable, MultipleInstanceError
@@ -39,6 +39,25 @@ try:
     algorithms = [ a for a in algorithms if not a.startswith('shake_') ]
 except AttributeError:
     algorithms = hashlib.algorithms
+
+
+# This has been added to traitlets, but is not released as of traitlets 4.3.1,
+# so a copy is included here for now.
+class Callable(TraitType):
+    """A trait which is callable.
+
+    Notes
+    -----
+    Classes are callable, as are instances
+    with a __call__() method."""
+
+    info_text = 'a callable'
+
+    def validate(self, obj, value):
+        if callable(value):
+            return value
+        else:
+            self.error(obj, value)
 
 
 class SignatureStore(object):

--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -287,7 +287,10 @@ class NotebookNotary(LoggingConfigurable):
             app.initialize(argv=[])
         return app.data_dir
 
-    store = Instance(SignatureStore)
+    store = Instance(SignatureStore,
+        help="""The storage backend for notebook signatures.
+        The default uses an SQLite database.
+        """).tag(config=True)
 
     @default('store')
     def _store_default(self):

--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -61,25 +61,6 @@ class SignatureStore(object):
         """
         raise NotImplementedError
 
-    # Convenience for filesystem-based stores
-
-    _data_dir = None
-    @property
-    def data_dir(self):
-        if self._data_dir is None:
-            app = None
-            try:
-                if JupyterApp.initialized():
-                    app = JupyterApp.instance()
-            except MultipleInstanceError:
-                pass
-            if app is None:
-                # create an app, without the global instance
-                app = JupyterApp()
-                app.initialize(argv=[])
-            self._data_dir = app.data_dir
-        return self._data_dir
-
 
 class MemorySignatureStore(SignatureStore):
     """Non-persistent storage of signatures in memory.

--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -182,7 +182,7 @@ class SQLiteSignatureStore(SignatureStore, LoggingConfigurable):
             return
         self.db.execute("""INSERT OR IGNORE INTO nbsignatures
             (algorithm, signature, last_seen) VALUES (?, ?, ?)""",
-                        (algorithm, hash, datetime.utcnow())
+                        (algorithm, digest, datetime.utcnow())
                         )
         self.db.execute("""UPDATE nbsignatures SET last_seen = ? WHERE
             algorithm = ? AND
@@ -404,7 +404,7 @@ class NotebookNotary(LoggingConfigurable):
         if nb.nbformat < 3:
             return False
         signature = self.compute_signature(nb)
-        return self.store.check_signature(signature)
+        return self.store.check_signature(signature, self.algorithm)
     
     def sign(self, nb):
         """Sign a notebook, indicating that its output is trusted on this machine
@@ -414,7 +414,7 @@ class NotebookNotary(LoggingConfigurable):
         if nb.nbformat < 3:
             return
         signature = self.compute_signature(nb)
-        self.store.store_signature(signature)
+        self.store.store_signature(signature, self.algorithm)
     
     def unsign(self, nb):
         """Ensure that a notebook is untrusted
@@ -422,7 +422,7 @@ class NotebookNotary(LoggingConfigurable):
         by removing its signature from the trusted database, if present.
         """
         signature = self.compute_signature(nb)
-        self.store.remove_signature(signature)
+        self.store.remove_signature(signature, self.algorithm)
     
     def mark_cells(self, nb, trusted):
         """Mark cells as trusted if the notebook's signature can be verified

--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -507,6 +507,10 @@ class TrustNotebookApp(JupyterApp):
     
     Otherwise, you will have to re-execute the notebook to see output.
     """
+    # This command line tool should use the same config file as the notebook
+    @default('config_file_name')
+    def _config_file_name_default(self):
+        return 'jupyter_notebook_config'
     
     examples = """
     jupyter trust mynotebook.ipynb and_this_one.ipynb

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -16,6 +16,7 @@ import unittest
 
 from .base import TestsBase
 
+from traitlets.config import Config
 from nbformat import read, sign, write
 
 class TestNotary(TestsBase):
@@ -229,6 +230,24 @@ class TestNotary(TestsBase):
         self.assertIn('Signing notebook: <stdin>', out)
         out = sign_stdin(self.nb3)
         self.assertIn('already signed: <stdin>', out)
+
+class SampleSigStore(sign.MemorySignatureStore):
+    def __init__(self, a):
+        print("Initialising", a)
+        self._a = a
+
+
+def test_config_store():
+    store = sign.MemorySignatureStore()
+
+    # traitlets.config deepcopy-s config values when applying them to the class,
+    # so checking 'notary.store is store' doesn't work. :-(
+    # We check for this attribute instead.
+    store._a = 'foo'
+    c = Config()
+    c.NotebookNotary.store = store
+    notary = sign.NotebookNotary(config=c)
+    assert notary.store._a == 'foo'
 
 class SignatureStoreTests(unittest.TestCase):
     def setUp(self):

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -89,9 +89,9 @@ class TestNotary(TestsBase):
         nbs = [
             copy.deepcopy(self.nb) for i in range(10)
         ]
-        for row in self.notary.db.execute("SELECT * FROM nbsignatures"):
+        for row in self.notary.store.db.execute("SELECT * FROM nbsignatures"):
             print(row)
-        self.notary.cache_size = 8
+        self.notary.store.cache_size = 8
         for i, nb in enumerate(nbs[:8]):
             nb.metadata.dirty = i
             self.notary.sign(nb)

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -12,6 +12,7 @@ import sys
 import time
 import tempfile
 import testpath
+import unittest
 
 from .base import TestsBase
 
@@ -228,3 +229,20 @@ class TestNotary(TestsBase):
         self.assertIn('Signing notebook: <stdin>', out)
         out = sign_stdin(self.nb3)
         self.assertIn('already signed: <stdin>', out)
+
+class SignatureStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.store = sign.MemorySignatureStore()
+
+    def test_basics(self):
+        digest = '0123457689abcef'
+        algo = 'fake_sha'
+        assert not self.store.check_signature(digest, algo)
+        self.store.store_signature(digest, algo)
+        assert self.store.check_signature(digest, algo)
+        self.store.remove_signature(digest, algo)
+        assert not self.store.check_signature(digest, algo)
+
+class SQLiteSignatureStoreTests(SignatureStoreTests):
+    def setUp(self):
+        self.store = sign.SQLiteSignatureStore(':memory:')

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -231,23 +231,13 @@ class TestNotary(TestsBase):
         out = sign_stdin(self.nb3)
         self.assertIn('already signed: <stdin>', out)
 
-class SampleSigStore(sign.MemorySignatureStore):
-    def __init__(self, a):
-        print("Initialising", a)
-        self._a = a
-
-
 def test_config_store():
     store = sign.MemorySignatureStore()
 
-    # traitlets.config deepcopy-s config values when applying them to the class,
-    # so checking 'notary.store is store' doesn't work. :-(
-    # We check for this attribute instead.
-    store._a = 'foo'
     c = Config()
-    c.NotebookNotary.store = store
+    c.NotebookNotary.store_factory = lambda: store
     notary = sign.NotebookNotary(config=c)
-    assert notary.store._a == 'foo'
+    assert notary.store is store
 
 class SignatureStoreTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This makes signature storage pluggable at `NotebookNotary.store`, and provides two implementations: 

- `SQLiteSignatureStore` is the default
- `MemorySignatureStore` is a fallback and an example for other implementations.

I'm experimenting with configuring the store as an instance rather than the factory pattern we use elsewhere. This relies on using Python config files, and means that configuration would look like this:

```python
from sqlsigs import MySQLSignatureStore
c.NotebookNotary.store = MySQLSignatureStore('127.0.0.1', database='nbsignatures')

# Rather than:
c.NotebookNotary.store_type = 'sqlsigs.MySQLSignatureStore'
c.MySQLSignatureStore.server = '127.0.0.1'
c.MySQLSignatureStore.database = 'nbsignatures'
```