### PR TITLE
DOC: Use proper URL for attachment example

### DIFF
--- a/docs/format_description.rst
+++ b/docs/format_description.rst
@@ -312,7 +312,7 @@ keyed by filename that represents the files attached to the cell.
     {
       "cell_type" : "markdown",
       "metadata" : {},
-      "source" : ["Here is an *inline* image ![inline image](attachment://test.png)"],
+      "source" : ["Here is an *inline* image ![inline image](attachment:test.png)"],
       "attachments" : {
         "test.png": {
             "image/png" : "base64-encoded-png-data"


### PR DESCRIPTION
This reverts part of #67.
See also #66 and https://github.com/jupyter/notebook/issues/1655.