### PR TITLE
add encoding to tests base class fopen function

### DIFF
--- a/nbformat/tests/base.py
+++ b/nbformat/tests/base.py
@@ -7,13 +7,13 @@ Contains base test class for nbformat
 
 import os
 import unittest
-
+import io
 
 class TestsBase(unittest.TestCase):
     """Base tests class."""
 
-    def fopen(self, f, mode=u'r'):
-        return open(os.path.join(self._get_files_path(), f), mode)
+    def fopen(self, f, mode=u'r',encoding='utf-8'):
+        return io.open(os.path.join(self._get_files_path(), f), mode, encoding=encoding)
 
 
     def _get_files_path(self):


### PR DESCRIPTION
Should close #74 by modifying the base class being used.

Also, for py2/py3 compatibility I changed it to use `io.open` as is done in the rest of the code base.