### PR TITLE
Add Store.close

### DIFF
--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -160,7 +160,7 @@ class SQLiteSignatureStore(SignatureStore, LoggingConfigurable):
                 old_db_location = db_file + ".bak"
                 if db is not None:
                     db.close()
-                self.log.warn(
+                self.log.warning(
                     ("The signatures database cannot be opened; maybe it is corrupted or encrypted. "
                      "You may need to rerun your notebooks to ensure that they are trusted to run Javascript. "
                      "The old signatures database has been renamed to %s and a new one has been created."),
@@ -172,7 +172,7 @@ class SQLiteSignatureStore(SignatureStore, LoggingConfigurable):
                 except (sqlite3.DatabaseError, sqlite3.OperationalError):
                     if db is not None:
                         db.close()
-                    self.log.warn(
+                    self.log.warning(
                         ("Failed commiting signatures database to disk. "
                          "You may need to move the database file to a non-networked file system, "
                          "using config option `NotebookNotary.db_file`. "
@@ -331,7 +331,7 @@ class NotebookNotary(LoggingConfigurable):
     def _store_factory_default(self):
         def factory():
             if sqlite3 is None:
-                self.log.warn("Missing SQLite3, all notebooks will be untrusted!")
+                self.log.warning("Missing SQLite3, all notebooks will be untrusted!")
                 return MemorySignatureStore()
             return SQLiteSignatureStore(self.db_file)
         return factory
@@ -395,7 +395,7 @@ class NotebookNotary(LoggingConfigurable):
         try:
             os.chmod(self.secret_file, 0o600)
         except OSError:
-            self.log.warn(
+            self.log.warning(
                 "Could not set permissions on %s",
                 self.secret_file
             )

--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -137,6 +137,7 @@ class SQLiteSignatureStore(SignatureStore, LoggingConfigurable):
         self.db = self._connect_db(db_file)
 
     def _connect_db(self, db_file):
+        db = None
         kwargs = dict(
             detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)
         try:
@@ -145,6 +146,8 @@ class SQLiteSignatureStore(SignatureStore, LoggingConfigurable):
         except (sqlite3.DatabaseError, sqlite3.OperationalError):
             if db_file != ':memory:':
                 old_db_location = db_file + ".bak"
+                if db is not None:
+                    db.close()
                 self.log.warn(
                     ("The signatures database cannot be opened; maybe it is corrupted or encrypted. "
                      "You may need to rerun your notebooks to ensure that they are trusted to run Javascript. "

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -46,8 +46,8 @@ class TestNotary(TestsBase):
             db_file=invalid_sql_file,
             secret=b'secret',
         )
-        self.addCleanup(invalid_notary.store.close)
         invalid_notary.sign(self.nb)
+        invalid_notary.store.close()
 
         testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file))
         testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file + '.bak'))

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -34,6 +34,7 @@ class TestNotary(TestsBase):
             self.nb3 = read(f, as_version=3)
     
     def tearDown(self):
+        self.notary.store.db.close()
         shutil.rmtree(self.data_dir)
    
     def test_invalid_db_file(self):
@@ -49,6 +50,8 @@ class TestNotary(TestsBase):
 
         testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file))
         testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file + '.bak'))
+        invalid_notary.store.db.close()
+
     
     def test_algorithms(self):
         last_sig = ''

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -34,7 +34,7 @@ class TestNotary(TestsBase):
             self.nb3 = read(f, as_version=3)
     
     def tearDown(self):
-        self.notary.store.db.close()
+        self.notary.store.close()
         shutil.rmtree(self.data_dir)
    
     def test_invalid_db_file(self):
@@ -46,11 +46,11 @@ class TestNotary(TestsBase):
             db_file=invalid_sql_file,
             secret=b'secret',
         )
+        self.addCleanup(invalid_notary.store.close)
         invalid_notary.sign(self.nb)
 
         testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file))
         testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file + '.bak'))
-        invalid_notary.store.db.close()
 
     
     def test_algorithms(self):

--- a/nbformat/tests/test_sign.py
+++ b/nbformat/tests/test_sign.py
@@ -227,7 +227,9 @@ class TestNotary(TestsBase):
             p.stdin.close()
             p.wait()
             self.assertEqual(p.returncode, 0)
-            return p.stdout.read().decode('utf8', 'replace')
+            out = p.stdout.read().decode('utf8', 'replace')
+            p.stdout.close()
+            return out
 
         out = sign_stdin(self.nb3)
         self.assertIn('Signing notebook: <stdin>', out)


### PR DESCRIPTION
so that db connections can be explicitly closed. It's a no-op in the base class for stores that don't have anything to open.

Discovered by @vidartf because the fact that we don't close db files causes errors during cleanup of the tests on Windows.

also found a few `log.warn`s to update.