### PR TITLE
Add appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+# environment variables
+environment:
+  matrix:
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_MAJOR: 3
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_MAJOR: 2
+      PYTHON_ARCH: "32"
+
+# scripts that run after cloning repository
+install:
+  # Ensure python scripts are from right version:
+  - 'SET "PATH=%PYTHON%\\Scripts;%PATH%"'
+  # Install our package:
+  - pip install codecov
+  - 'pip install --upgrade ".[test]"'
+
+build: off
+
+# to run your custom scripts instead of automatic tests
+test_script:
+  - 'py.test -v --cov nbformat nbformat'
+
+on_success:
+  - codecov


### PR DESCRIPTION
Adds a simple appveyor recipe (3.5 x64 / 2.7 x86, + codecov).

Based on top of #86 as it won't succeed the AppVeyor tests if not.