### PR TITLE
Add files for `nbformat-schema` npm package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,10 @@ include COPYING.md
 include CONTRIBUTING.md
 include README.md
 
+# Javascript
+include package.json
+include index.js
+
 # Documentation
 graft docs
 exclude docs/\#*

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+exports.v3 = require('./nbformat/v3/nbformat.v3.schema.json');
+exports.v4 = require('./nbformat/v4/nbformat.v4.schema.json');
+

--- a/nbformat/_version.py
+++ b/nbformat/_version.py
@@ -1,2 +1,3 @@
+# Make sure to update package.json, too!
 version_info = (4, 3, 0, 'dev')
 __version__ = '.'.join(map(str, version_info))

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nbformat-schema",
   "version": "4.3.0",
   "description": "JSON schemata for Jupyter notebook formats",
+  "main": "index.js",
   "files": [
       "nbformat/v3/nbformat.v3.schema.json",
       "nbformat/v4/nbformat.v4.schema.json"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "nbformat-schema",
+  "version": "4.3.0",
+  "description": "JSON schemata for Jupyter notebook formats",
+  "files": [
+      "nbformat/v3/nbformat.v3.schema.json",
+      "nbformat/v4/nbformat.v4.schema.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jupyter/nbformat.git"
+  },
+  "keywords": [
+    "jupyter",
+    "notebook",
+    "json-schema"
+  ],
+  "author": "Project Jupyter Contributors",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/jupyter/nbformat/issues"
+  },
+  "homepage": "https://nbformat.readthedocs.io"
+}


### PR DESCRIPTION
The schema files are left unmoved in the npm package. `index.js` loads the schemas with their versions, so you can do:

```javascript
let nbformat = require('nbformat-schema').v4
```

This is just the raw schema JSON, not a validator or anything.

I've uploaded an example build as [minrk-nbformat-schema](https://www.npmjs.com/package/minrk-nbformat-schema).

cc @rgbkrk @SylvainCorlay @blink1073

closes #70