### PR TITLE
declare source_hidden and outputs_hidden official code cell metadata

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@
 Changes in nbformat
 =========================
 
+4.4
+===
+
+`4.4 on GitHub <https://github.com/jupyter/nbformat/milestone/9>`__
+
+- Metadata is now being specified more tightly amongst Jupyter frontends
+
+
 4.3
 ===
 

--- a/docs/format_description.rst
+++ b/docs/format_description.rst
@@ -378,6 +378,9 @@ Additional fields may be added.
 Cell metadata
 -------------
 
+Official Jupyter metadata, as used by Jupyter frontends should be placed in the
+`metadata.jupyter` namespace, for example `metadata.jupyter.foo = "bar"`.
+
 The following metadata keys are defined at the cell level:
 
 =========== =============== ==============
@@ -390,6 +393,15 @@ format      'mime/type'     The mime-type of a :ref:`Raw NBConvert Cell <raw nbc
 name        str             A name for the cell. Should be unique
 tags        list of str     A list of string tags on the cell. Commas are not allowed in a tag
 =========== =============== ==============
+
+The following metadata keys are defined at the cell level within the `jupyter` namespace
+
+=============== =============== ==============
+Key             Value           Interpretation
+=============== =============== ==============
+source_hidden   bool            Whether the cell's source should be shown
+outputs_hidden  bool            Whether the cell's outputs should be shown
+=============== =============== ==============
 
 Output metadata
 ---------------

--- a/nbformat/tests/test4jupyter_metadata.ipynb
+++ b/nbformat/tests/test4jupyter_metadata.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+      "outputs_hidden": false,
+      "source_hidden": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"hello\")"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -48,6 +48,13 @@ class TestValidator(TestsBase):
         validate(nb)
         self.assertEqual(isvalid(nb), True)
 
+    def test_nb4jupyter_metadata(self):
+        """Test that a notebook with a jupyter metadata passes validation"""
+        with self.fopen(u'test4jupyter_metadata.ipynb', u'r') as f:
+            nb = read(f, as_version=4)
+        validate(nb)
+        self.assertEqual(isvalid(nb), True)
+
     def test_invalid(self):
         """Test than an invalid notebook does not pass validation"""
         # this notebook has a few different errors:

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -126,6 +126,15 @@
                             "description": "Raw cell metadata format for nbconvert.",
                             "type": "string"
                         },
+                        "jupyter": {
+                          "description": "Official Jupyter Metadata for Raw Cells",
+                          "type": "object",
+                          "additionalProperties": true,
+                            "source_hidden": {
+                                "description": "Whether the source is hidden.",
+                                "type": "boolean"
+                            }
+                        },
                         "name": {"$ref": "#/definitions/misc/metadata_name"},
                         "tags": {"$ref": "#/definitions/misc/metadata_tags"}
                     }

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -150,7 +150,16 @@
                     "type": "object",
                     "properties": {
                         "name": {"$ref": "#/definitions/misc/metadata_name"},
-                        "tags": {"$ref": "#/definitions/misc/metadata_tags"}
+                        "tags": {"$ref": "#/definitions/misc/metadata_tags"},
+                        "jupyter": {
+                          "description": "Official Jupyter Metadata for Markdown Cells",
+                          "type": "object",
+                          "additionalProperties": true,
+                            "source_hidden": {
+                                "description": "Whether the source is hidden.",
+                                "type": "boolean"
+                            }
+                        }
                     },
                     "additionalProperties": true
                 },
@@ -175,7 +184,7 @@
                     "additionalProperties": true,
                     "properties": {
                         "jupyter": {
-                          "description": "Official Jupyter Metadata",
+                          "description": "Official Jupyter Metadata for Code Cells",
                           "type": "object",
                           "additionalProperties": true,
                             "source_hidden": {

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -174,6 +174,19 @@
                     "type": "object",
                     "additionalProperties": true,
                     "properties": {
+                        "jupyter": {
+                          "description": "Official Jupyter Metadata",
+                          "type": "object",
+                          "additionalProperties": true,
+                            "source_hidden": {
+                                "description": "Whether the source is hidden.",
+                                "type": "boolean"
+                            },
+                            "outputs_hidden": {
+                                "description": "Whether the outputs are hidden.",
+                                "type": "boolean"
+                            }
+                        },
                         "collapsed": {
                             "description": "Whether the cell is collapsed/expanded.",
                             "type": "boolean"


### PR DESCRIPTION
Following discussion from Jupyter Team Meeting, here's a follow on PR for the metadata I'd like to see us standandardize on.

This PR uses `source_hidden` within `.cells[].metadata.input_hidden`, only for code cells (since markdown and raw cells imply hidden by default in most views (I'd be happy to add it to markdown if someone wanted it to be explicit though...)

xrefs:

* https://github.com/jupyter/notebook/issues/534 
* https://github.com/nteract/nteract/pull/1697

/cc @ellisonbg @mpacer @jcb91