### PR TITLE
Catch OSError from renaming non-existant file

### DIFF
--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -171,7 +171,7 @@ class SQLiteSignatureStore(SignatureStore, LoggingConfigurable):
                     os.rename(db_file, old_db_location)
                     db = sqlite3.connect(db_file, **kwargs)
                     self.init_db(db)
-                except (sqlite3.DatabaseError, sqlite3.OperationalError):
+                except (sqlite3.DatabaseError, sqlite3.OperationalError, OSError):
                     if db is not None:
                         db.close()
                     self.log.warning(


### PR DESCRIPTION
In some circumstances, we can fail to connect to the SQLite database without creating the file. Then attempting to move it to the backup location fails as well. This catches that error and falls back to using an in-memory database for signatures.

Closes jupyter/notebook#2621