### PR TITLE
add relaxation flag to validator call

### DIFF
--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -50,7 +50,7 @@ def _allow_undefined(schema):
     )
     return schema
 
-def get_validator(version=None, version_minor=None):
+def get_validator(version=None, version_minor=None, relax_add_props=False):
     """Load the JSON schema into a Validator"""
     if version is None:
         from .. import current_nbformat
@@ -63,7 +63,7 @@ def get_validator(version=None, version_minor=None):
 
     version_tuple = (version, version_minor)
 
-    if version_tuple not in validators:
+    if version_tuple not in validators or relax_add_props:
         try:
             v.nbformat_schema
         except AttributeError:
@@ -78,6 +78,11 @@ def get_validator(version=None, version_minor=None):
             schema_json = _relax_additional_properties(schema_json)
             # and allow undefined cell types and outputs
             schema_json = _allow_undefined(schema_json)
+
+        if relax_add_props:
+            # this allows properties to be added for intermediate
+            # representations while validating for all other kinds of errors
+            schema_json = _relax_additional_properties(schema_json)
 
         validators[version_tuple] = Validator(schema_json)
     return validators[version_tuple]
@@ -216,7 +221,7 @@ def better_validation_error(error, version, version_minor):
     return NotebookValidationError(error, ref)
 
 
-def validate(nbjson, ref=None, version=None, version_minor=None):
+def validate(nbjson, ref=None, version=None, version_minor=None, relax_add_props=False):
     """Checks whether the given notebook JSON conforms to the current
     notebook format schema.
 
@@ -226,7 +231,7 @@ def validate(nbjson, ref=None, version=None, version_minor=None):
         from .reader import get_version
         (version, version_minor) = get_version(nbjson)
 
-    validator = get_validator(version, version_minor)
+    validator = get_validator(version, version_minor, relax_add_props=relax_add_props)
 
     if validator is None:
         # no validator


### PR DESCRIPTION
This arises in the context of determining what sorts of intermediate representations we want for notebooks in nbconvert: https://github.com/jupyter/nbconvert/pull/643

It was suggested by @minrk that we only allow additional fields (and no additional values for existing fields or the deletion of fields) in terms of this intermediate representation.

Up until now, we thought that preprocessors had always only created valid notebooks. That turns out to be not be the case (https://github.com/jupyter/nbconvert/pull/645).

It would be nice to be able to establish that the only things allowed by preprocessors is to exactly what we say it is.

To that end, this adds a flag to the `validate` API (and the `get_validator` API)  for communicating that that specific relaxation is to be adhered to and otherwise the notebook is entirely valid.

This allows the use of `nbformat.validate(…, relax_add_props=True)` in the nbconvert preprocessor checks which will ensure that 3rd party preprocessors similarly adhere to this restriction on the nbconvert internal representation.