### PR TITLE
Catch dict-like vals in  __setitem__, apply from_dict()

### DIFF
--- a/nbformat/notebooknode.py
+++ b/nbformat/notebooknode.py
@@ -8,7 +8,7 @@ class NotebookNode(Struct):
     """A dict-like node with attribute-access"""
 
     def __setitem__(self, key, value):
-        if isinstance(value, dict):
+        if isinstance(value, Mapping):
             value = from_dict(value)
         super(NotebookNode, self).__setitem__(key, value)
 

--- a/nbformat/notebooknode.py
+++ b/nbformat/notebooknode.py
@@ -2,9 +2,36 @@
 
 from ipython_genutils.ipstruct import Struct
 
+
 class NotebookNode(Struct):
     """A dict-like node with attribute-access"""
-    pass
+
+    def __setitem__(self, key, value):
+        """Set an item with check for allownew.
+        Examples
+        --------
+        >>> s = Struct()
+        >>> s['a'] = 10
+        >>> s.allow_new_attr(False)
+        >>> s['a'] = 10
+        >>> s['a']
+        10
+        >>> try:
+        ...     s['b'] = 20
+        ... except KeyError:
+        ...     print('this is not allowed')
+        ...
+        this is not allowed
+        """
+        if not self._allownew and key not in self:
+            raise KeyError(
+                "can't create new attribute %s when allow_new_attr(False)" % key)
+
+        if isinstance(value, dict):
+            dict.__setitem__(self, key, from_dict(value))
+        else:
+            dict.__setitem__(self, key, value)
+
 
 def from_dict(d):
     """Convert dict to dict-like NotebookNode
@@ -19,5 +46,3 @@ def from_dict(d):
         return [from_dict(i) for i in d]
     else:
         return d
-
-

--- a/nbformat/notebooknode.py
+++ b/nbformat/notebooknode.py
@@ -8,7 +8,7 @@ class NotebookNode(Struct):
     """A dict-like node with attribute-access"""
 
     def __setitem__(self, key, value):
-        if isinstance(value, Mapping):
+        if isinstance(value, Mapping) and not isinstance(value, NotebookNode):
             value = from_dict(value)
         super(NotebookNode, self).__setitem__(key, value)
 
@@ -42,7 +42,7 @@ def from_dict(d):
     This does not check that the contents of the dictionary make a valid
     notebook or part of a notebook.
     """
-    if isinstance(d, dict) and not isinstance(d, NotebookNode):
+    if isinstance(d, dict):
         return NotebookNode({k: from_dict(v) for k, v in d.items()})
     elif isinstance(d, (tuple, list)):
         return [from_dict(i) for i in d]

--- a/nbformat/notebooknode.py
+++ b/nbformat/notebooknode.py
@@ -42,7 +42,7 @@ def from_dict(d):
     This does not check that the contents of the dictionary make a valid
     notebook or part of a notebook.
     """
-    if isinstance(d, dict):
+    if isinstance(d, dict) and not isinstance(d, NotebookNode):
         return NotebookNode({k: from_dict(v) for k, v in d.items()})
     elif isinstance(d, (tuple, list)):
         return [from_dict(i) for i in d]

--- a/nbformat/notebooknode.py
+++ b/nbformat/notebooknode.py
@@ -10,14 +10,14 @@ class NotebookNode(Struct):
         """Set an item with check for allownew.
         Examples
         --------
-        >>> s = Struct()
-        >>> s['a'] = 10
-        >>> s.allow_new_attr(False)
-        >>> s['a'] = 10
-        >>> s['a']
+        >>> n = NotebookNode()
+        >>> n['a'] = 10
+        >>> n.allow_new_attr(False)
+        >>> n['a'] = 10
+        >>> n['a']
         10
         >>> try:
-        ...     s['b'] = 20
+        ...     n['b'] = 20
         ... except KeyError:
         ...     print('this is not allowed')
         ...

--- a/nbformat/notebooknode.py
+++ b/nbformat/notebooknode.py
@@ -1,47 +1,49 @@
 """NotebookNode - adding attribute access to dicts"""
 
 from ipython_genutils.ipstruct import Struct
+from collections import Mapping
 
 
 class NotebookNode(Struct):
     """A dict-like node with attribute-access"""
 
     def __setitem__(self, key, value):
-        """Set an item with check for allownew.
-        Examples
-        --------
-        >>> n = NotebookNode()
-        >>> n['a'] = 10
-        >>> n.allow_new_attr(False)
-        >>> n['a'] = 10
-        >>> n['a']
-        10
-        >>> try:
-        ...     n['b'] = 20
-        ... except KeyError:
-        ...     print('this is not allowed')
-        ...
-        this is not allowed
-        """
-        if not self._allownew and key not in self:
-            raise KeyError(
-                "can't create new attribute %s when allow_new_attr(False)" % key)
-
         if isinstance(value, dict):
-            dict.__setitem__(self, key, from_dict(value))
-        else:
-            dict.__setitem__(self, key, value)
+            value = from_dict(value)
+        super(NotebookNode, self).__setitem__(key, value)
+
+    def update(self, *args, **kwargs):
+        """
+        A dict-like update method based on CPython's MutableMapping `update`
+        method.
+        """
+        if len(args) > 1:
+            raise TypeError('update expected at most 1 arguments, got %d' %
+                            len(args))
+        if args:
+            other = args[0]
+            if isinstance(other, Mapping):
+                for key in other:
+                    self[key] = other[key]
+            elif hasattr(other, "keys"):
+                for key in other.keys():
+                    self[key] = other[key]
+            else:
+                for key, value in other:
+                    self[key] = value
+        for key, value in kwargs.items():
+            self[key] = value
 
 
 def from_dict(d):
     """Convert dict to dict-like NotebookNode
-    
+
     Recursively converts any dict in the container to a NotebookNode.
     This does not check that the contents of the dictionary make a valid
     notebook or part of a notebook.
     """
     if isinstance(d, dict):
-        return NotebookNode({k:from_dict(v) for k,v in d.items()})
+        return NotebookNode({k: from_dict(v) for k, v in d.items()})
     elif isinstance(d, (tuple, list)):
         return [from_dict(i) for i in d]
     else:

--- a/nbformat/v4/nbbase.py
+++ b/nbformat/v4/nbbase.py
@@ -9,7 +9,7 @@ helpers to build the structs in the right form.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ..notebooknode import from_dict, NotebookNode
+from ..notebooknode import NotebookNode
 
 # Change this when incrementing the nbformat version
 nbformat = 4
@@ -35,9 +35,9 @@ def new_output(output_type, data=None, **kwargs):
         output.metadata = NotebookNode()
         output.data = NotebookNode()
     # load from args:
-    output.update(from_dict(kwargs))
+    output.update(kwargs)
     if data is not None:
-        output.data = from_dict(data)
+        output.data = data
     # validate
     validate(output, output_type)
     return output
@@ -95,7 +95,7 @@ def new_code_cell(source='', **kwargs):
         source=source,
         outputs=[],
     )
-    cell.update(from_dict(kwargs))
+    cell.update(kwargs)
 
     validate(cell, 'code_cell')
     return cell
@@ -107,7 +107,7 @@ def new_markdown_cell(source='', **kwargs):
         source=source,
         metadata=NotebookNode(),
     )
-    cell.update(from_dict(kwargs))
+    cell.update(kwargs)
 
     validate(cell, 'markdown_cell')
     return cell
@@ -119,7 +119,7 @@ def new_raw_cell(source='', **kwargs):
         source=source,
         metadata=NotebookNode(),
     )
-    cell.update(from_dict(kwargs))
+    cell.update(kwargs)
 
     validate(cell, 'raw_cell')
     return cell
@@ -132,6 +132,6 @@ def new_notebook(**kwargs):
         metadata=NotebookNode(),
         cells=[],
     )
-    nb.update(from_dict(kwargs))
+    nb.update(kwargs)
     validate(nb)
     return nb

--- a/nbformat/v4/nbjson.py
+++ b/nbformat/v4/nbjson.py
@@ -8,7 +8,7 @@ import json
 
 from ipython_genutils import py3compat
 
-from .nbbase import from_dict
+from ..notebooknode import from_dict
 from .rwbase import (
     NotebookReader, NotebookWriter, rejoin_lines, split_lines, strip_transient
 )


### PR DESCRIPTION
Directly addresses feature in #102. 

only difference from the suggested implementation by @minrk is that I added this to `__setitem__` instead of `__setattr__`. I did this because `__setattr__`  was calling `__setitem__` anyway and this also covers the case where assignment is accomplished standard the standard object["key"] syntax. This is already supported by `NotebookNode` (it inherits from `ipython_genutils.ipstruct.Struct` which is is a dictlike & has a `__setitem__` implementation).

My one concern is that tab completion (in the notebook) is not catching attribute values set in this way (even if they are set using the attribute syntax, which is odd).