### PR TITLE
Add bumpversion config file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,29 @@
+[bumpversion]
+current_version = 4.5.0.dev
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(.(?P<suffix>.+))?
+serialize = 
+	{major}.{minor}.{patch}.{suffix}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:suffix]
+optional_value = final
+values = 
+	dev
+	final
+
+[bumpversion:file:nbformat/_version.py]
+parse = (?P<major>\d+),\s*(?P<minor>\d+),\s*(?P<patch>\d+)(,\s*['"](?P<suffix>\w+)['"])?
+serialize = 
+	{major}, {minor}, {patch}, '{suffix}'
+	{major}, {minor}, {patch}
+
+[bumpversion:file:docs/conf.py]
+parse = (?P<major>\d+).(?P<minor>\d+)
+serialize = {major}.{minor}
+search = version = '{current_version}'
+replace = version = '{new_version}'
+
+[bumpversion:file:package.json]
+parse = (?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)
+serialize = {major}.{minor}.{patch}
+


### PR DESCRIPTION
This makes it simpler to update version numbers when doing a release:

```shell
bumpversion suffix  # Remove the .dev
# Commit, test, publish, tag release
bumpversion minor
git commit -am "Back to dev"
```

I'm always worried that I'm going to forget one of the version numbers when doing a release, and the extra `package.json` file makes that particularly likely.