### PR TITLE
Return all validation errors when loading notebook

### DIFF
--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -8,7 +8,7 @@ import os
 from .base import TestsBase
 from jsonschema import ValidationError
 from nbformat import read
-from ..validator import isvalid, validate
+from ..validator import isvalid, validate, iter_validate
 
 
 class TestValidator(TestsBase):
@@ -91,3 +91,14 @@ class TestValidator(TestsBase):
         self.assertRegexpMatches(s, "source.* is a required property")
         self.assertRegexpMatches(s, r"On instance\[u?['\"].*cells['\"]\]\[0\]")
         self.assertLess(len(s.splitlines()), 10)
+
+    def test_iter_validation_error(self):
+        with self.fopen(u'invalid.ipynb', u'r') as f:
+            nb = read(f, as_version=4)
+
+        errors = list(iter_validate(nb))
+        assert len(errors) == 3
+        assert {e.ref for e in errors} == {'markdown_cell', 'heading_cell', 'bad stream'}
+
+    def test_iter_validation_empty(self):
+        assert list(iter_validate({})) == list()

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -246,7 +246,7 @@ def validate(nbjson, ref=None, version=None, version_minor=None, relax_add_props
 
     try:
         err = next(iter_validate(nbjson, ref=ref, version=version, version_minor=version_minor, relax_add_props=relax_add_props))
-        raise better_validation_error(err, version, version_minor)
+        raise err
     except StopIteration:
         return None
 
@@ -268,6 +268,9 @@ def iter_validate(nbjson, ref=None, version=None, version_minor=None, relax_add_
         return iter(list())
 
     if ref:
-        return validator.iter_errors(nbjson, {'$ref' : '#/definitions/%s' % ref})
+        errors = validator.iter_errors(nbjson, {'$ref' : '#/definitions/%s' % ref})
     else:
-        return validator.iter_errors(nbjson)
+        errors = validator.iter_errors(nbjson)
+
+    for error in errors:
+        yield better_validation_error(error, version, version_minor)

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -23,6 +23,7 @@ except ImportError as e:
     raise ImportError(str(e) + verbose_msg)
 
 from ipython_genutils.importstring import import_item
+from .reader import get_version
 
 
 validators = {}
@@ -240,6 +241,9 @@ def validate(nbjson, ref=None, version=None, version_minor=None, relax_add_props
 
     Raises ValidationError if not valid.
     """
+    if version is None:
+        version, version_minor = get_version(nbjson)
+
     try:
         err = next(iter_validate(nbjson, ref=ref, version=version, version_minor=version_minor, relax_add_props=relax_add_props))
         raise better_validation_error(err, version, version_minor)
@@ -254,8 +258,7 @@ def iter_validate(nbjson, ref=None, version=None, version_minor=None, relax_add_
     Returns a generator of all ValidationErrors if not valid.
     """
     if version is None:
-        from .reader import get_version
-        (version, version_minor) = get_version(nbjson)
+        version, version_minor = get_version(nbjson)
 
     validator = get_validator(version, version_minor, relax_add_props=relax_add_props)
 
@@ -263,7 +266,6 @@ def iter_validate(nbjson, ref=None, version=None, version_minor=None, relax_add_
         # no validator
         warnings.warn("No schema for validating v%s notebooks" % version, UserWarning)
         return iter(list())
-
 
     if ref:
         return validator.iter_errors(nbjson, {'$ref' : '#/definitions/%s' % ref})

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -265,7 +265,7 @@ def iter_validate(nbjson, ref=None, version=None, version_minor=None, relax_add_
     if validator is None:
         # no validator
         warnings.warn("No schema for validating v%s notebooks" % version, UserWarning)
-        return iter(list())
+        raise StopIteration
 
     if ref:
         errors = validator.iter_errors(nbjson, {'$ref' : '#/definitions/%s' % ref})

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -244,11 +244,10 @@ def validate(nbjson, ref=None, version=None, version_minor=None, relax_add_props
     if version is None:
         version, version_minor = get_version(nbjson)
 
-    try:
-        err = next(iter_validate(nbjson, ref=ref, version=version, version_minor=version_minor, relax_add_props=relax_add_props))
-        raise err
-    except StopIteration:
-        return None
+    for error in iter_validate(nbjson, ref=ref, version=version, 
+                                version_minor=version_minor, 
+                                relax_add_props=relax_add_props):
+        raise error
 
 
 def iter_validate(nbjson, ref=None, version=None, version_minor=None, relax_add_props=False):
@@ -265,7 +264,7 @@ def iter_validate(nbjson, ref=None, version=None, version_minor=None, relax_add_
     if validator is None:
         # no validator
         warnings.warn("No schema for validating v%s notebooks" % version, UserWarning)
-        raise StopIteration
+        return
 
     if ref:
         errors = validator.iter_errors(nbjson, {'$ref' : '#/definitions/%s' % ref})

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -262,7 +262,7 @@ def iter_validate(nbjson, ref=None, version=None, version_minor=None, relax_add_
     if validator is None:
         # no validator
         warnings.warn("No schema for validating v%s notebooks" % version, UserWarning)
-        return
+        return iter(list())
 
 
     if ref:


### PR DESCRIPTION
Uses the iter_errors method from jsonschema to allow collecting all validation errors from a notebook in one validation pass.  Prior behavior would halt validation on the first error.

This will allow better user interaction by notifying the user of all the errors in notebook file at one time rather than one-each-time-user-tries-to-reload-notebook.

@minrk Thanks for your help (and sharp eye) in putting together this PR. 