### PR TITLE
put in logic for handling nbjson kwargs

### DIFF
--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -261,13 +261,21 @@ def validate(nbdict=None, ref=None, version=None, version_minor=None,
         raise error
 
 
-def iter_validate(nbdict, ref=None, version=None, version_minor=None,
-                  relax_add_props=False):
+def iter_validate(nbdict=None, ref=None, version=None, version_minor=None,
+                  relax_add_props=False, nbjson=None):
     """Checks whether the given notebook dict-like object conforms to the
     current notebook format schema.
 
     Returns a generator of all ValidationErrors if not valid.
     """
+    # backwards compatibility for nbjson argument
+    if nbdict is not None:
+        pass
+    elif nbjson is not None:
+        nbdict = nbjson
+    else:
+        raise TypeError("iter_validate() missing 1 required argument: 'nbdict'")
+
     if version is None:
         version, version_minor = get_version(nbdict)
 

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -250,7 +250,7 @@ def validate(nbdict=None, ref=None, version=None, version_minor=None,
     elif nbjson is not None:
         nbdict = nbjson
     else:
-        raise ValidationError("Object to validate was not provided.")
+        raise TypeError("validate() missing 1 required argument: 'nbdict'")
 
     if version is None:
         version, version_minor = get_version(nbdict)

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -244,13 +244,13 @@ def validate(nbdict=None, ref=None, version=None, version_minor=None,
     Raises ValidationError if not valid.
     """
 
-    if nbdict is None:  # nbjson backwards compat: trigger if nbdict is not set
-        if isinstance(nbjson, str):  # if nbjson is str, convert it
-            nbdict = reads(nbjson)
-        elif isinstance(nbjson, dict):  # if nbjson is dict-like, assign it
-            nbdict = nbjson
-        else:  # otherwise there is no nbdict, nothing to validate
-            raise ValidationError("No dict-like notebook object was given.")
+    # backwards compatibility for nbjson argument
+    if nbdict is not None:
+        pass
+    elif nbjson is not None:
+        nbdict = nbjson
+    else:
+        raise ValidationError("Object to validate was not provided.")
 
     if version is None:
         version, version_minor = get_version(nbdict)

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -23,7 +23,7 @@ except ImportError as e:
     raise ImportError(str(e) + verbose_msg)
 
 from ipython_genutils.importstring import import_item
-from .reader import get_version
+from .reader import get_version, reads
 
 
 validators = {}
@@ -235,29 +235,41 @@ def better_validation_error(error, version, version_minor):
     return NotebookValidationError(error, ref)
 
 
-def validate(nbjson, ref=None, version=None, version_minor=None, relax_add_props=False):
-    """Checks whether the given notebook JSON conforms to the current
-    notebook format schema.
+def validate(nbdict=None, ref=None, version=None, version_minor=None,
+             relax_add_props=False, nbjson=None):
+    """Checks whether the given notebook dict-like object
+    conforms to the current notebook format schema.
+
 
     Raises ValidationError if not valid.
     """
-    if version is None:
-        version, version_minor = get_version(nbjson)
 
-    for error in iter_validate(nbjson, ref=ref, version=version, 
-                                version_minor=version_minor, 
-                                relax_add_props=relax_add_props):
+    if nbdict is None:  # nbjson backwards compat: trigger if nbdict is not set
+        if isinstance(nbjson, str):  # if nbjson is str, convert it
+            nbdict = reads(nbjson)
+        elif isinstance(nbjson, dict):  # if nbjson is dict-like, assign it
+            nbdict = nbjson
+        else:  # otherwise there is no nbdict, nothing to validate
+            raise ValidationError("No dict-like notebook object was given.")
+
+    if version is None:
+        version, version_minor = get_version(nbdict)
+
+    for error in iter_validate(nbdict, ref=ref, version=version,
+                               version_minor=version_minor,
+                               relax_add_props=relax_add_props):
         raise error
 
 
-def iter_validate(nbjson, ref=None, version=None, version_minor=None, relax_add_props=False):
-    """Checks whether the given notebook JSON conforms to the current
-    notebook format schema.
+def iter_validate(nbdict, ref=None, version=None, version_minor=None,
+                  relax_add_props=False):
+    """Checks whether the given notebook dict-like object conforms to the
+    current notebook format schema.
 
     Returns a generator of all ValidationErrors if not valid.
     """
     if version is None:
-        version, version_minor = get_version(nbjson)
+        version, version_minor = get_version(nbdict)
 
     validator = get_validator(version, version_minor, relax_add_props=relax_add_props)
 
@@ -267,9 +279,9 @@ def iter_validate(nbjson, ref=None, version=None, version_minor=None, relax_add_
         return
 
     if ref:
-        errors = validator.iter_errors(nbjson, {'$ref' : '#/definitions/%s' % ref})
+        errors = validator.iter_errors(nbdict, {'$ref' : '#/definitions/%s' % ref})
     else:
-        errors = validator.iter_errors(nbjson)
+        errors = validator.iter_errors(nbdict)
 
     for error in errors:
         yield better_validation_error(error, version, version_minor)


### PR DESCRIPTION
Based on discussion in #112  we should make our docstrings and signatures for `validate` (and `iter_validate`) more straightforward. Currently the argument is called nbjson and the docs call for  notebook JSON (presumed to be a string).  All it will accept in actuality is a nbdict-like object.

This solves this with a few pieces:
1. change the main argument to be named `nbdict` for both `validate` and `iter_validate`
2.  fix the signature & docs for both `validate` and `iter_validate`.
3. avoid backwards compatibility for anyone using the `nbjson` keyword argument (↬@takluyver for pointing this out)
4. allow optional handling of nbjson as a json string by passing it through to `nbformat.reader.reads()` which reads json strings in and passes it back as a dict-like 
    a. Note what is passed back is not guaranteed to be a valid notebook since (unlike when calling the `nbformat.reads()` command), no validation occurs.

Finally, if there is nothing passed in positionally (or nothing assigned to `nbdict`) it raises a `ValidationError`. I could have it raise a `TypeError` instead since that's closer to what the problem was (in that they didn't follow the convention for the signature, even though the signature strictly speaking didn't require a positional argument anymore).