### PR TITLE
Adds more info about name's meaning for cells

### DIFF
--- a/docs/format_description.rst
+++ b/docs/format_description.rst
@@ -64,7 +64,7 @@ All cells have the following basic structure:
 .. sourcecode:: python
 
     {
-      "cell_type" : "name",
+      "cell_type" : "type",
       "metadata" : {},
       "source" : "single string or [list, of, strings]",
     }
@@ -390,7 +390,7 @@ collapsed   bool            Whether the cell's output container should be collap
 autoscroll  bool or 'auto'  Whether the cell's output is scrolled, unscrolled, or autoscrolled
 deletable   bool            If False, prevent deletion of the cell
 format      'mime/type'     The mime-type of a :ref:`Raw NBConvert Cell <raw nbconvert cells>`
-name        str             A name for the cell. Should be unique
+name        str             A name for the cell. Should be unique across the notebook. Uniqueness must be verified outside of the json schema. 
 tags        list of str     A list of string tags on the cell. Commas are not allowed in a tag
 =========== =============== ==============
 

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -364,7 +364,7 @@
 
         "misc": {
             "metadata_name": {
-                "description": "The cell's name. If present, must be a non-empty string. Cell names are expected to be unique across all the cells in a given notebook.",
+                "description": "The cell's name. If present, must be a non-empty string. Cell names are expected to be unique across all the cells in a given notebook. This criterion cannot be checked by the json schema and must be established by an additional check.",
                 "type": "string",
                 "pattern": "^.+$"
             },

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -364,7 +364,7 @@
 
         "misc": {
             "metadata_name": {
-                "description": "The cell's name. If present, must be a non-empty string. Must be unique across all the cells of a given notebook.",
+                "description": "The cell's name. If present, must be a non-empty string. Cell names are expected to be unique across all the cells in a given notebook.",
                 "type": "string",
                 "pattern": "^.+$"
             },


### PR DESCRIPTION
This just clarifies the use of `cell.metadata.name` in the format. 

Specifically it suggests that it is expected to be unique for all cells in the notebook and it specifies that this uniqueness condition needs something in addition to the schema to check for that fact.

Closes #114 