### PR TITLE
allow read file to be bytes

### DIFF
--- a/nbformat/__init__.py
+++ b/nbformat/__init__.py
@@ -71,6 +71,8 @@ def reads(s, as_version, **kwargs):
     nb : NotebookNode
         The notebook that was read.
     """
+    if isinstance(s, bytes):
+        s = s.decode('utf8')
     nb = reader.reads(s, **kwargs)
     if as_version is not NO_CONVERT:
         nb = convert(nb, as_version)


### PR DESCRIPTION
I use [hdfscontents](https://github.com/hopshadoop/hdfscontents) to save the notebook to HDFS, and the return type is bytes when read notebook from HDFS which loads to the failure to load notebook, so I add read bytes in the read function.