### PR TITLE
Fail invalid notebook validation

### DIFF
--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -102,3 +102,8 @@ class TestValidator(TestsBase):
 
     def test_iter_validation_empty(self):
         assert list(iter_validate({})) == list()
+
+    def test_validation_no_version(self):
+        """Test that an invalid notebook with no version fails validation"""
+        with self.assertRaises(ValidationError) as e:
+            validate({'invalid': 'notebook'})

--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -68,8 +68,9 @@ class TestValidator(TestsBase):
         self.assertEqual(isvalid(nb), False)
 
     def test_validate_empty(self):
-        """Test that an empty dict can be validated without error"""
-        validate({})
+        """Test that an empty notebook (invalid) fails validation"""
+        with self.assertRaises(ValidationError) as e:
+            validate({})
 
     def test_future(self):
         """Test than a notebook from the future with extra keys passes validation"""
@@ -101,7 +102,10 @@ class TestValidator(TestsBase):
         assert {e.ref for e in errors} == {'markdown_cell', 'heading_cell', 'bad stream'}
 
     def test_iter_validation_empty(self):
-        assert list(iter_validate({})) == list()
+        """Test that an empty notebook (invalid) fails validation via iter_validate"""
+        errors = list(iter_validate({}))
+        assert len(errors) == 1
+        assert type(errors[0]) == ValidationError
 
     def test_validation_no_version(self):
         """Test that an invalid notebook with no version fails validation"""

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -283,7 +283,7 @@ def iter_validate(nbdict=None, ref=None, version=None, version_minor=None,
 
     if validator is None:
         # no validator
-        warnings.warn("No schema for validating v%s notebooks" % version, UserWarning)
+        yield ValidationError("No schema for validating v%s notebooks" % version)
         return
 
     if ref:


### PR DESCRIPTION
Fixes https://github.com/jupyter/nbformat/issues/123

Note that this PR changes what nbformat does when asked to validate invalid notebooks with no version. Based on https://github.com/jupyter/nbformat/issues/123#issuecomment-375266782 I think that's OK. My test updates to account for this are isolated in https://github.com/jupyter/nbformat/commit/05582b9185980aef8dd26637f521318de85b7c1e so it should be easy to check if the behaviour changes I'm making are reasonable.