### PR TITLE
Avoid a DeprecationWarning of collections module import

### DIFF
--- a/nbformat/notebooknode.py
+++ b/nbformat/notebooknode.py
@@ -1,7 +1,10 @@
 """NotebookNode - adding attribute access to dicts"""
 
 from ipython_genutils.ipstruct import Struct
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 
 class NotebookNode(Struct):


### PR DESCRIPTION
I got the following deprecation warning when I run some tests that using `nbformat` module with `Python 3.7`:

```
.tox/python3.7/lib/python3.7/site-packages/nbformat/notebooknode.py:4
  /home/toor/workspace/sqlitebiter/.tox/python3.7/lib/python3.7/site-packages/nbformat/notebooknode.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping
```

This PR aims to avoid the `DeprecationWarning`