### PR TITLE
Include description & tags as official notebook metadata keys

### DIFF
--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -64,6 +64,19 @@
                     "description": "The title of the notebook document",
                     "type": "string"
                 },
+                "description": {
+                    "description": "A summary of the notebook",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "The cell's tags. Tags must be unique, and must not contain commas.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "pattern": "^[^,]+$"
+                    }
+                },
                 "authors": {
                     "description": "The author(s) of the notebook document",
                     "type": "array",

--- a/nbformat/v4/nbformat.v4.schema.json
+++ b/nbformat/v4/nbformat.v4.schema.json
@@ -69,7 +69,7 @@
                     "type": "string"
                 },
                 "tags": {
-                    "description": "The cell's tags. Tags must be unique, and must not contain commas.",
+                    "description": "Tags to classify a notebooks topics. Tags must be unique, and must not contain commas.",
                     "type": "array",
                     "uniqueItems": true,
                     "items": {


### PR DESCRIPTION
This adds `description` and `tags` fields as top level keys for re-use and standardization.