### PR TITLE
document editable metadata flag

### DIFF
--- a/docs/format_description.rst
+++ b/docs/format_description.rst
@@ -389,6 +389,7 @@ Key         Value           Interpretation
 collapsed   bool            Whether the cell's output container should be collapsed
 scrolled    bool or 'auto'  Whether the cell's output is scrolled, unscrolled, or autoscrolled
 deletable   bool            If False, prevent deletion of the cell
+editable    bool            If False, prevent editing of the cell.  The cell can still be deleted, unless deletable is also False.
 format      'mime/type'     The mime-type of a :ref:`Raw NBConvert Cell <raw nbconvert cells>`
 name        str             A name for the cell. Should be unique across the notebook. Uniqueness must be verified outside of the json schema. 
 tags        list of str     A list of string tags on the cell. Commas are not allowed in a tag


### PR DESCRIPTION
I believe this is how it works in JupyterLab.  I also submitted another PR with how it works in Jupyter classic.  Please accept one of them!   I vote for the Jupyter classic behavior, but will implement whichever approach is accepted in CoCalc, unless you wait too long to decide (since I don't want to confuse users by switching back and forth).