### PR TITLE
adding documentation about markup used

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ todo_include_todos = False
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -296,7 +296,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'jupyterclient': ('https://jupyter_client.readthedocs.org/en/stable', None),
+    'jupyterclient': ('https://jupyter-client.readthedocs.io/en/stable', None),
     'nbconvert': ('https://nbconvert.readthedocs.org/en/stable', None),
     'notebook': ('https://jupyter-notebook.readthedocs.org/en/stable', None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Contents:
    :maxdepth: 2
 
    format_description
+   markup
    api
    changelog
 

--- a/docs/markup.rst
+++ b/docs/markup.rst
@@ -1,0 +1,66 @@
+.. _markup:
+
+========================
+Supported markup formats
+========================
+
+The Jupyter Notebook format supports Markdown in text cells.
+There is not a strict specification for the flavor of markdown that
+is supported, but this page should help guide the user / developer
+in understanding what behavior to expect with Jupyter interfaces and
+markup languages.
+
+
+What flavor of Markdown does the notebook format support?
+=========================================================
+
+Most Jupyter Notebook interfaces use the `marked.js <https://github.com/markedjs/marked>`_
+JavaScript library for rendering markdown. This supports markdown in
+the following markdown flavors:
+
+*  `CommonMark <http://spec.commonmark.org/0.29/>`_.
+* `GitHub Flavored Markdown <https://github.github.com/gfm/>`_
+
+See the `Marked.js specification page <https://marked.js.org/#/README.md#specifications>`_
+for more information.
+
+.. note::
+
+    Currently, as the Marked.js specification changes, so to will the
+    behavior of Markdown in many notebook interfaces.
+
+
+MathJax configuration
+=====================
+
+There are a few extra modifications that Jupyter interfaces tend to use for
+rendering markdown. Specifically, they automatically render mathematical
+equations using `MathJax <https://www.mathjax.org/>`_.
+
+This is currently the MathJax configuration that is used:
+
+.. code:: javascript
+
+    {
+        tex2jax: {
+            inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+            displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+            processEscapes: true,
+            processEnvironments: true
+        },
+        MathML: {
+            extensions: ['content-mathml.js']
+        },
+        displayAlign: 'center',
+        "HTML-CSS": {
+            availableFonts: [],
+            imageFont: null,
+            preferredFont: null,
+            webFont: "STIX-Web",
+            styles: {'.MathJax_Display': {"margin": 0}},
+            linebreaks: { automatic: true }
+        },
+    }
+
+See the `MathJax script for the classic Notebook UI <https://github.com/jupyter/notebook/blob/master/notebook/static/notebook/js/mathjaxutils.js>`_
+for one example.


### PR DESCRIPTION
This adds a short page that describes some of the Markdown rendering behavior. It's just meant to be a description of the current state of things, rather than formalizing anything new. As such it is a bit hand-wavy about some things, which (I think) is an accurate reflection of Jupyter's current treatment of markdown.

(also two minor documentation config fixes)

Partially addresses #96 