### PR TITLE
Removal of support for python 2 and prep for 5.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 dist: xenial
 python:
-    - nightly
     - 3.8
     - 3.7
     - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
     - 3.7
     - 3.6
     - 3.5
+os: linux
+arch:
+    - amd64
+    - arm64
 sudo: false
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: python
 dist: xenial
 python:
+    - nightly
     - 3.8
     - 3.7
     - 3.6
     - 3.5
-    - 3.4
-    - 2.7
-os: linux
-arch:
-    - amd64
-    - arm64
 sudo: false
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -11,3 +11,19 @@ and Python APIs for working with notebooks.
 There is also a JSON schema for notebook format versions >= 3.
 
 [Jupyter Notebook format]: https://nbformat.readthedocs.org/en/latest/format_description.html
+
+## Installation
+
+From the command line:
+
+``` {.sourceCode .bash}
+pip install nbformat
+```
+
+## Python Version Support
+
+This library supported python 2.7 and python 3.5+ for `4.x.x` releases. With python 2's end-of-life nbformat `5.x.x` is now python 3.5+ only. Support for 3.5 will be dropped when it's officially sunset by the python organization.
+
+## Contributing
+
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how to setup a local development environment and make code changes back to nbformat.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,31 @@
+# Releasing
+
+## Prerequisites
+
+- First check that the docs/changelog.rst is up to date for the next release version
+
+## Push to GitHub
+
+Change from patch to minor or major for appropriate version updates.
+
+```bash
+bumpversion suffix  # Remove the .dev
+# Commit, test, publish, tag release
+bumpversion patch
+git push && git push --tags
+```
+
+## Push to PyPI
+
+```bash
+rm -rf dist/*
+rm -rf build/*
+python setup.py sdist bdist_wheel
+# Double check the dist/* files have the right verison and install the wheel to ensure it's good
+pip install dist/*
+twine upload dist/*
+```
+
+## Prep repo for development
+
+- Change package.json version to next version (e.g. `4.4` -> `4.5`)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,6 @@ environment:
       PYTHON_VERSION: "3.5.x"
       PYTHON_MAJOR: 3
       PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_MAJOR: 2
-      PYTHON_ARCH: "32"
 
 # scripts that run after cloning repository
 install:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ Changes in nbformat
 
 - ``nbformat`` is now Python 3 only (>= 3.5)
 - Add execution timings in code cell metadata for v4 spec.
-  ``"metadata": { "execution": {...}}`` should be populated with kernel specific
+  ``"metadata": { "execution": {...}}`` should be populated with kernel-specific
   timing information.
 - Documentation for how markup is used in notebooks added
 - Link to json schema docs from format page added
@@ -21,8 +21,8 @@ Changes in nbformat
 - Clarified info about :ref:`name`'s meaning for cells
 - Added a default execution_count of None for new_output_cell('execute_result')
 - Added support for handling nbjson kwargs
-- Wheels now correctly have a LICENCE file
-- Tavis builds now have a few more execution environments
+- Wheels now correctly have a LICENSE file
+- Travis builds now have a few more execution environments
 
 4.4
 ===

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,26 @@
 Changes in nbformat
 =========================
 
+5.0
+===
+
+`5.0 on GitHub https://github.com/jupyter/nbformat/milestone/5`__
+
+- ``nbformat`` is now Python 3 only (>= 3.5)
+- Add execution timings in code cell metadata for v4 spec.
+  ``"metadata": { "execution": {...}}`` should be populated with kernel specific
+  timing information.
+- Documentation for how markup is used in notebooks added
+- Link to json schema docs from format page added
+- Documented the editable metadata flag
+- Update description for collapsed field
+- Documented nbformat versions 4.0-4.3 with accurate json schema specification files
+- Clarified info about :ref:`name`'s meaning for cells
+- Added a default execution_count of None for new_output_cell('execute_result')
+- Added support for handling nbjson kwargs
+- Wheels now correctly have a LICENCE file
+- Tavis builds now have a few more execution environments
+
 4.4
 ===
 
@@ -14,9 +34,9 @@ Changes in nbformat
 - Introduce ``source_hidden`` and ``outputs_hidden`` as official front-end
   metadata fields to indicate hiding source and outputs areas. **NB**: These
   fields should not be used to hide elements in exported formats.
-- Fix ending the redundant storage of signatures in the signature database. 
+- Fix ending the redundant storage of signatures in the signature database.
 - :func:`nbformat.validate` can be set to not raise a ValidationError if
-  additional properties are included. 
+  additional properties are included.
 - Fix for errors with connecting and backing up the signature database.
 - Dict-like objects added to NotebookNode attributes are now transformed to be
   NotebookNode objects; transformation also works for `.update()`.

--- a/nbformat/__init__.py
+++ b/nbformat/__init__.py
@@ -6,7 +6,6 @@ Use this module to read or write notebook files as particular nbformat versions.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 import io
-from ipython_genutils import py3compat
 
 from traitlets.log import get_logger
 from ._version import version_info, __version__
@@ -51,7 +50,7 @@ NO_CONVERT = Sentinel('NO_CONVERT', __name__,
 
 def reads(s, as_version, **kwargs):
     """Read a notebook from a string and return the NotebookNode object as the given version.
-    
+
     The string can contain a notebook of any version.
     The notebook will be returned `as_version`, converting, if necessary.
 
@@ -134,7 +133,7 @@ def read(fp, as_version, **kwargs):
     nb : NotebookNode
         The notebook that was read.
     """
-    if isinstance(fp, (py3compat.unicode_type, bytes)):
+    if isinstance(fp, (str, bytes)):
         with io.open(fp, encoding='utf-8') as f:
             return read(f, as_version, **kwargs)
 
@@ -143,9 +142,9 @@ def read(fp, as_version, **kwargs):
 
 def write(nb, fp, version=NO_CONVERT, **kwargs):
     """Write a notebook to a file in a given nbformat version.
-    
+
     The file-like object must accept unicode input.
-    
+
     Parameters
     ----------
     nb : NotebookNode
@@ -159,7 +158,7 @@ def write(nb, fp, version=NO_CONVERT, **kwargs):
         If unspecified, or specified as nbformat.NO_CONVERT,
         the notebook's own version will be used and no conversion performed.
     """
-    if isinstance(fp, (py3compat.unicode_type, bytes)):
+    if isinstance(fp, (str, bytes)):
         with io.open(fp, 'w', encoding='utf-8') as f:
             return write(nb, f, version=version, **kwargs)
 

--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -20,7 +20,7 @@ except ImportError:
     except ImportError:
         sqlite3 = None
 
-from ipython_genutils.py3compat import unicode_type, cast_bytes, cast_unicode
+from ipython_genutils.py3compat import cast_bytes, cast_unicode
 from traitlets import (
     Instance, Bytes, Enum, Any, Unicode, Bool, Integer, TraitType,
     default, observe,
@@ -82,7 +82,7 @@ class SignatureStore(object):
         Should not raise if the signature is not stored.
         """
         raise NotImplementedError
-    
+
     def close(self):
         """Close any open connections this store may use.
 
@@ -206,7 +206,7 @@ class SQLiteSignatureStore(SignatureStore, LoggingConfigurable):
             return
         if not self.check_signature(digest, algorithm):
             self.db.execute("""
-                INSERT INTO nbsignatures (algorithm, signature, last_seen) 
+                INSERT INTO nbsignatures (algorithm, signature, last_seen)
                 VALUES (?, ?, ?)
                 """, (algorithm, digest, datetime.utcnow())
             )
@@ -261,7 +261,7 @@ class SQLiteSignatureStore(SignatureStore, LoggingConfigurable):
 
 def yield_everything(obj):
     """Yield every item in a container as bytes
-    
+
     Allows any JSONable object to be passed to an HMAC digester
     without having to serialize the whole thing.
     """
@@ -275,14 +275,14 @@ def yield_everything(obj):
         for element in obj:
             for b in yield_everything(element):
                 yield b
-    elif isinstance(obj, unicode_type):
+    elif isinstance(obj, str):
         yield obj.encode('utf8')
     else:
-        yield unicode_type(obj).encode('utf8')
+        yield str(obj).encode('utf8')
 
 def yield_code_cells(nb):
     """Iterator that yields all cells in a notebook
-    
+
     nbformat version independent
     """
     if nb.nbformat >= 4:
@@ -298,7 +298,7 @@ def yield_code_cells(nb):
 @contextmanager
 def signature_removed(nb):
     """Context manager for operating on a notebook with its signature removed
-    
+
     Used for excluding the previous signature when computing a notebook's signature.
     """
     save_signature = nb['metadata'].pop('signature', None)
@@ -311,7 +311,7 @@ def signature_removed(nb):
 
 class NotebookNotary(LoggingConfigurable):
     """A class for computing and verifying notebook signatures."""
-    
+
     data_dir = Unicode()
     @default('data_dir')
     def _data_dir_default(self):
@@ -351,19 +351,19 @@ class NotebookNotary(LoggingConfigurable):
         if not self.data_dir:
             return ':memory:'
         return os.path.join(self.data_dir, u'nbsignatures.db')
-    
+
     algorithm = Enum(algorithms, default_value='sha256',
         help="""The hashing algorithm used to sign notebooks."""
     ).tag(config=True)
     @observe('algorithm')
     def _algorithm_changed(self, change):
         self.digestmod = getattr(hashlib, change.new)
-    
+
     digestmod = Any()
     @default('digestmod')
     def _digestmod_default(self):
         return getattr(hashlib, self.algorithm)
-    
+
     secret_file = Unicode(
         help="""The file where the secret key is stored."""
     ).tag(config=True)
@@ -372,7 +372,7 @@ class NotebookNotary(LoggingConfigurable):
         if not self.data_dir:
             return ''
         return os.path.join(self.data_dir, 'notebook_secret')
-    
+
     secret = Bytes(
         help="""The secret key with which notebooks are signed."""
     ).tag(config=True)
@@ -390,7 +390,7 @@ class NotebookNotary(LoggingConfigurable):
     def __init__(self, **kwargs):
         super(NotebookNotary, self).__init__(**kwargs)
         self.store = self.store_factory()
-    
+
     def _write_secret_file(self, secret):
         """write my secret to my secret_file"""
         self.log.info("Writing notebook-signing key to %s", self.secret_file)
@@ -404,10 +404,10 @@ class NotebookNotary(LoggingConfigurable):
                 self.secret_file
             )
         return secret
-    
+
     def compute_signature(self, nb):
         """Compute a notebook's signature
-        
+
         by hashing the entire contents of the notebook via HMAC digest.
         """
         hmac = HMAC(self.secret, digestmod=self.digestmod)
@@ -416,17 +416,17 @@ class NotebookNotary(LoggingConfigurable):
             # sign the whole thing
             for b in yield_everything(nb):
                 hmac.update(b)
-        
+
         return hmac.hexdigest()
-    
+
     def check_signature(self, nb):
         """Check a notebook's stored signature
-        
+
         If a signature is stored in the notebook's metadata,
         a new signature is computed and compared with the stored value.
-        
+
         Returns True if the signature is found and matches, False otherwise.
-        
+
         The following conditions must all be met for a notebook to be trusted:
         - a signature is stored in the form 'scheme:hexdigest'
         - the stored scheme matches the requested scheme
@@ -437,55 +437,55 @@ class NotebookNotary(LoggingConfigurable):
             return False
         signature = self.compute_signature(nb)
         return self.store.check_signature(signature, self.algorithm)
-    
+
     def sign(self, nb):
         """Sign a notebook, indicating that its output is trusted on this machine
-        
+
         Stores hash algorithm and hmac digest in a local database of trusted notebooks.
         """
         if nb.nbformat < 3:
             return
         signature = self.compute_signature(nb)
         self.store.store_signature(signature, self.algorithm)
-    
+
     def unsign(self, nb):
         """Ensure that a notebook is untrusted
-        
+
         by removing its signature from the trusted database, if present.
         """
         signature = self.compute_signature(nb)
         self.store.remove_signature(signature, self.algorithm)
-    
+
     def mark_cells(self, nb, trusted):
         """Mark cells as trusted if the notebook's signature can be verified
-        
+
         Sets ``cell.metadata.trusted = True | False`` on all code cells,
         depending on the *trusted* parameter. This will typically be the return
         value from ``self.check_signature(nb)``.
-        
+
         This function is the inverse of check_cells
         """
         if nb.nbformat < 3:
             return
-        
+
         for cell in yield_code_cells(nb):
             cell['metadata']['trusted'] = trusted
-    
+
     def _check_cell(self, cell, nbformat_version):
         """Do we trust an individual cell?
-        
+
         Return True if:
-        
+
         - cell is explicitly trusted
         - cell has no potentially unsafe rich output
-        
+
         If a cell has no output, or only simple print statements,
         it will always be trusted.
         """
         # explicitly trusted
         if cell['metadata'].pop("trusted", False):
             return True
-        
+
         # explicitly safe output
         if nbformat_version >= 4:
             unsafe_output_types = ['execute_result', 'display_data']
@@ -493,7 +493,7 @@ class NotebookNotary(LoggingConfigurable):
         else: # v3
             unsafe_output_types = ['pyout', 'display_data']
             safe_keys = {"output_type", "prompt_number", "metadata"}
-        
+
         for output in cell['outputs']:
             output_type = output['output_type']
             if output_type in unsafe_output_types:
@@ -501,16 +501,16 @@ class NotebookNotary(LoggingConfigurable):
                 output_keys = set(output)
                 if output_keys.difference(safe_keys):
                     return False
-        
+
         return True
-    
+
     def check_cells(self, nb):
         """Return whether all code cells are trusted.
-        
+
         A cell is trusted if the 'trusted' field in its metadata is truthy, or
         if it has no potentially unsafe outputs.
         If there are no code cells, return True.
-        
+
         This function is the inverse of mark_cells.
         """
         if nb.nbformat < 3:
@@ -539,31 +539,31 @@ class TrustNotebookApp(JupyterApp):
     version = __version__
     description="""Sign one or more Jupyter notebooks with your key,
     to trust their dynamic (HTML, Javascript) output.
-    
+
     Otherwise, you will have to re-execute the notebook to see output.
     """
     # This command line tool should use the same config file as the notebook
     @default('config_file_name')
     def _config_file_name_default(self):
         return 'jupyter_notebook_config'
-    
+
     examples = """
     jupyter trust mynotebook.ipynb and_this_one.ipynb
     """
-    
+
     flags = trust_flags
-    
+
     reset = Bool(False,
         help="""If True, delete the trusted signature cache.
         After reset, all previously signed notebooks will become untrusted.
         """
     ).tag(config=True)
-    
+
     notary = Instance(NotebookNotary)
     @default('notary')
     def _notary_default(self):
         return NotebookNotary(parent=self, data_dir=self.data_dir)
-    
+
     def sign_notebook_file(self, notebook_path):
         """Sign a notebook from the filesystem"""
         if not os.path.exists(notebook_path):
@@ -572,7 +572,7 @@ class TrustNotebookApp(JupyterApp):
         with io.open(notebook_path, encoding='utf8') as f:
             nb = read(f, NO_CONVERT)
         self.sign_notebook(nb, notebook_path)
-    
+
     def sign_notebook(self, nb, notebook_path='<stdin>'):
         """Sign a notebook that's been loaded"""
         if self.notary.check_signature(nb):
@@ -580,12 +580,12 @@ class TrustNotebookApp(JupyterApp):
         else:
             print("Signing notebook: %s" % notebook_path)
             self.notary.sign(nb)
-    
+
     def generate_new_key(self):
         """Generate a new notebook signature key"""
         print("Generating new notebook key: %s" % self.notary.secret_file)
         self.notary._write_secret_file(os.urandom(1024))
-    
+
     def start(self):
         if self.reset:
             if os.path.exists(self.notary.db_file):

--- a/nbformat/v1/nbbase.py
+++ b/nbformat/v1/nbbase.py
@@ -20,7 +20,6 @@ import pprint
 import uuid
 
 from ipython_genutils.ipstruct import Struct
-from ipython_genutils.py3compat import unicode_type
 
 #-----------------------------------------------------------------------------
 # Code
@@ -47,7 +46,7 @@ def new_code_cell(code=None, prompt_number=None):
     cell = NotebookNode()
     cell.cell_type = u'code'
     if code is not None:
-        cell.code = unicode_type(code)
+        cell.code = str(code)
     if prompt_number is not None:
         cell.prompt_number = int(prompt_number)
     return cell
@@ -57,7 +56,7 @@ def new_text_cell(text=None):
     """Create a new text cell."""
     cell = NotebookNode()
     if text is not None:
-        cell.text = unicode_type(text)
+        cell.text = str(text)
     cell.cell_type = u'text'
     return cell
 

--- a/nbformat/v2/nbbase.py
+++ b/nbformat/v2/nbbase.py
@@ -25,7 +25,6 @@ import pprint
 import uuid
 
 from ipython_genutils.ipstruct import Struct
-from ipython_genutils.py3compat import unicode_type
 
 #-----------------------------------------------------------------------------
 # Code
@@ -54,25 +53,25 @@ def new_output(output_type=None, output_text=None, output_png=None,
     """Create a new code cell with input and output"""
     output = NotebookNode()
     if output_type is not None:
-        output.output_type = unicode_type(output_type)
+        output.output_type = str(output_type)
 
     if output_type != 'pyerr':
         if output_text is not None:
-            output.text = unicode_type(output_text)
+            output.text = str(output_text)
         if output_png is not None:
             output.png = bytes(output_png)
         if output_jpeg is not None:
             output.jpeg = bytes(output_jpeg)
         if output_html is not None:
-            output.html = unicode_type(output_html)
+            output.html = str(output_html)
         if output_svg is not None:
-            output.svg = unicode_type(output_svg)
+            output.svg = str(output_svg)
         if output_latex is not None:
-            output.latex = unicode_type(output_latex)
+            output.latex = str(output_latex)
         if output_json is not None:
-            output.json = unicode_type(output_json)
+            output.json = str(output_json)
         if output_javascript is not None:
-            output.javascript = unicode_type(output_javascript)
+            output.javascript = str(output_javascript)
 
     if output_type == u'pyout':
         if prompt_number is not None:
@@ -80,11 +79,11 @@ def new_output(output_type=None, output_text=None, output_png=None,
 
     if output_type == u'pyerr':
         if etype is not None:
-            output.etype = unicode_type(etype)
+            output.etype = str(etype)
         if evalue is not None:
-            output.evalue = unicode_type(evalue)
+            output.evalue = str(evalue)
         if traceback is not None:
-            output.traceback = [unicode_type(frame) for frame in list(traceback)]
+            output.traceback = [str(frame) for frame in list(traceback)]
 
     return output
 
@@ -95,9 +94,9 @@ def new_code_cell(input=None, prompt_number=None, outputs=None,
     cell = NotebookNode()
     cell.cell_type = u'code'
     if language is not None:
-        cell.language = unicode_type(language)
+        cell.language = str(language)
     if input is not None:
-        cell.input = unicode_type(input)
+        cell.input = str(input)
     if prompt_number is not None:
         cell.prompt_number = int(prompt_number)
     if outputs is None:
@@ -113,9 +112,9 @@ def new_text_cell(cell_type, source=None, rendered=None):
     """Create a new text cell."""
     cell = NotebookNode()
     if source is not None:
-        cell.source = unicode_type(source)
+        cell.source = str(source)
     if rendered is not None:
-        cell.rendered = unicode_type(rendered)
+        cell.rendered = str(rendered)
     cell.cell_type = cell_type
     return cell
 
@@ -124,7 +123,7 @@ def new_worksheet(name=None, cells=None):
     """Create a worksheet by name with with a list of cells."""
     ws = NotebookNode()
     if name is not None:
-        ws.name = unicode_type(name)
+        ws.name = str(name)
     if cells is None:
         ws.cells = []
     else:
@@ -152,29 +151,29 @@ def new_metadata(name=None, authors=None, license=None, created=None,
     """Create a new metadata node."""
     metadata = NotebookNode()
     if name is not None:
-        metadata.name = unicode_type(name)
+        metadata.name = str(name)
     if authors is not None:
         metadata.authors = list(authors)
     if created is not None:
-        metadata.created = unicode_type(created)
+        metadata.created = str(created)
     if modified is not None:
-        metadata.modified = unicode_type(modified)
+        metadata.modified = str(modified)
     if license is not None:
-        metadata.license = unicode_type(license)
+        metadata.license = str(license)
     if gistid is not None:
-        metadata.gistid = unicode_type(gistid)
+        metadata.gistid = str(gistid)
     return metadata
 
 def new_author(name=None, email=None, affiliation=None, url=None):
     """Create a new author."""
     author = NotebookNode()
     if name is not None:
-        author.name = unicode_type(name)
+        author.name = str(name)
     if email is not None:
-        author.email = unicode_type(email)
+        author.email = str(email)
     if affiliation is not None:
-        author.affiliation = unicode_type(affiliation)
+        author.affiliation = str(affiliation)
     if url is not None:
-        author.url = unicode_type(url)
+        author.url = str(url)
     return author
 

--- a/nbformat/v2/nbpy.py
+++ b/nbformat/v2/nbpy.py
@@ -17,7 +17,6 @@ Authors:
 #-----------------------------------------------------------------------------
 
 import re
-from ipython_genutils.py3compat import unicode_type
 from .rwbase import NotebookReader, NotebookWriter
 from .nbbase import new_code_cell, new_text_cell, new_worksheet, new_notebook
 
@@ -137,7 +136,7 @@ class PyWriter(NotebookWriter):
                         lines.extend([u'# ' + line for line in input.splitlines()])
                         lines.append(u'')
         lines.append('')
-        return unicode_type('\n'.join(lines))
+        return str('\n'.join(lines))
 
 
 _reader = PyReader()

--- a/nbformat/v2/rwbase.py
+++ b/nbformat/v2/rwbase.py
@@ -18,7 +18,7 @@ Authors:
 
 import pprint
 
-from ipython_genutils.py3compat import str_to_bytes, unicode_type, string_types
+from ipython_genutils.py3compat import str_to_bytes
 from .._compat import encodebytes, decodebytes
 
 #-----------------------------------------------------------------------------
@@ -27,7 +27,7 @@ from .._compat import encodebytes, decodebytes
 
 def restore_bytes(nb):
     """Restore bytes of image data from unicode-only formats.
-    
+
     Base64 encoding is handled elsewhere.  Bytes objects in the notebook are
     always b64-encoded. We DO NOT encode/decode around file formats.
     """
@@ -46,12 +46,12 @@ _multiline_outputs = ['text', 'html', 'svg', 'latex', 'javascript', 'json']
 
 def rejoin_lines(nb):
     """rejoin multiline text into strings
-    
+
     For reversing effects of ``split_lines(nb)``.
-    
+
     This only rejoins lines that have been split, so if text objects were not split
     they will pass through unchanged.
-    
+
     Used when reading JSON files that may have been passed through split_lines.
     """
     for ws in nb.worksheets:
@@ -74,26 +74,26 @@ def rejoin_lines(nb):
 
 def split_lines(nb):
     """split likely multiline text into lists of strings
-    
+
     For file output more friendly to line-based VCS. ``rejoin_lines(nb)`` will
     reverse the effects of ``split_lines(nb)``.
-    
+
     Used when writing JSON files.
     """
     for ws in nb.worksheets:
         for cell in ws.cells:
             if cell.cell_type == 'code':
-                if 'input' in cell and isinstance(cell.input, string_types):
+                if 'input' in cell and isinstance(cell.input, str):
                     cell.input = cell.input.splitlines()
                 for output in cell.outputs:
                     for key in _multiline_outputs:
                         item = output.get(key, None)
-                        if isinstance(item, string_types):
+                        if isinstance(item, str):
                             output[key] = item.splitlines()
             else: # text cell
                 for key in ['source', 'rendered']:
                     item = cell.get(key, None)
-                    if isinstance(item, string_types):
+                    if isinstance(item, str):
                         cell[key] = item.splitlines()
     return nb
 
@@ -102,7 +102,7 @@ def split_lines(nb):
 
 def base64_decode(nb):
     """Restore all bytes objects in the notebook from base64-encoded strings.
-    
+
     Note: This is never used
     """
     for ws in nb.worksheets:
@@ -110,11 +110,11 @@ def base64_decode(nb):
             if cell.cell_type == 'code':
                 for output in cell.outputs:
                     if 'png' in output:
-                        if isinstance(output.png, unicode_type):
+                        if isinstance(output.png, str):
                             output.png = output.png.encode('ascii')
                         output.png = decodebytes(output.png)
                     if 'jpeg' in output:
-                        if isinstance(output.jpeg, unicode_type):
+                        if isinstance(output.jpeg, str):
                             output.jpeg = output.jpeg.encode('ascii')
                         output.jpeg = decodebytes(output.jpeg)
     return nb
@@ -122,9 +122,9 @@ def base64_decode(nb):
 
 def base64_encode(nb):
     """Base64 encode all bytes objects in the notebook.
-    
+
     These will be b64-encoded unicode strings
-    
+
     Note: This is never used
     """
     for ws in nb.worksheets:

--- a/nbformat/v3/nbbase.py
+++ b/nbformat/v3/nbbase.py
@@ -13,7 +13,7 @@ import pprint
 import uuid
 
 from ipython_genutils.ipstruct import Struct
-from ipython_genutils.py3compat import cast_unicode, unicode_type
+from ipython_genutils.py3compat import cast_unicode
 
 #-----------------------------------------------------------------------------
 # Code
@@ -49,7 +49,7 @@ def new_output(output_type, output_text=None, output_png=None,
     """Create a new output, to go in the ``cell.outputs`` list of a code cell.
     """
     output = NotebookNode()
-    output.output_type = unicode_type(output_type)
+    output.output_type = str(output_type)
 
     if metadata is None:
         metadata = {}
@@ -92,7 +92,7 @@ def new_output(output_type, output_text=None, output_png=None,
 
     if output_type == u'stream':
         output.stream = 'stdout' if stream is None else cast_unicode(stream)
-    
+
     return output
 
 

--- a/nbformat/v3/nbjson.py
+++ b/nbformat/v3/nbjson.py
@@ -12,8 +12,6 @@ from .rwbase import (
     strip_transient,
 )
 
-from ipython_genutils import py3compat
-
 
 class BytesEncoder(json.JSONEncoder):
     """A JSON encoder that accepts b64 (and other *ascii*) bytestrings."""
@@ -46,8 +44,8 @@ class JSONWriter(NotebookWriter):
         nb = strip_transient(nb)
         if kwargs.pop('split_lines', True):
             nb = split_lines(nb)
-        return py3compat.str_to_unicode(json.dumps(nb, **kwargs), 'utf-8')
-    
+        return json.dumps(nb, **kwargs)
+
 
 _reader = JSONReader()
 _writer = JSONWriter()

--- a/nbformat/v3/rwbase.py
+++ b/nbformat/v3/rwbase.py
@@ -3,18 +3,17 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ipython_genutils import py3compat
-from ipython_genutils.py3compat import str_to_bytes, unicode_type, string_types
+from ipython_genutils.py3compat import str_to_bytes
 
 from .._compat import encodebytes, decodebytes
 
 
 def restore_bytes(nb):
     """Restore bytes of image data from unicode-only formats.
-    
+
     Base64 encoding is handled elsewhere.  Bytes objects in the notebook are
     always b64-encoded. We DO NOT encode/decode around file formats.
-    
+
     Note: this is never used
     """
     for ws in nb.worksheets:
@@ -34,7 +33,7 @@ _multiline_outputs = ['text', 'html', 'svg', 'latex', 'javascript', 'json']
 # FIXME: workaround for old splitlines()
 def _join_lines(lines):
     """join lines that have been written by splitlines()
-    
+
     Has logic to protect against `splitlines()`, which
     should have been `splitlines(True)`
     """
@@ -48,12 +47,12 @@ def _join_lines(lines):
 
 def rejoin_lines(nb):
     """rejoin multiline text into strings
-    
+
     For reversing effects of ``split_lines(nb)``.
-    
+
     This only rejoins lines that have been split, so if text objects were not split
     they will pass through unchanged.
-    
+
     Used when reading JSON files that may have been passed through split_lines.
     """
     for ws in nb.worksheets:
@@ -76,26 +75,26 @@ def rejoin_lines(nb):
 
 def split_lines(nb):
     """split likely multiline text into lists of strings
-    
+
     For file output more friendly to line-based VCS. ``rejoin_lines(nb)`` will
     reverse the effects of ``split_lines(nb)``.
-    
+
     Used when writing JSON files.
     """
     for ws in nb.worksheets:
         for cell in ws.cells:
             if cell.cell_type == 'code':
-                if 'input' in cell and isinstance(cell.input, string_types):
+                if 'input' in cell and isinstance(cell.input, str):
                     cell.input = cell.input.splitlines(True)
                 for output in cell.outputs:
                     for key in _multiline_outputs:
                         item = output.get(key, None)
-                        if isinstance(item, string_types):
+                        if isinstance(item, str):
                             output[key] = item.splitlines(True)
             else: # text, heading cell
                 for key in ['source', 'rendered']:
                     item = cell.get(key, None)
-                    if isinstance(item, string_types):
+                    if isinstance(item, str):
                         cell[key] = item.splitlines(True)
     return nb
 
@@ -104,7 +103,7 @@ def split_lines(nb):
 
 def base64_decode(nb):
     """Restore all bytes objects in the notebook from base64-encoded strings.
-    
+
     Note: This is never used
     """
     for ws in nb.worksheets:
@@ -112,11 +111,11 @@ def base64_decode(nb):
             if cell.cell_type == 'code':
                 for output in cell.outputs:
                     if 'png' in output:
-                        if isinstance(output.png, unicode_type):
+                        if isinstance(output.png, str):
                             output.png = output.png.encode('ascii')
                         output.png = decodebytes(output.png)
                     if 'jpeg' in output:
-                        if isinstance(output.jpeg, unicode_type):
+                        if isinstance(output.jpeg, str):
                             output.jpeg = output.jpeg.encode('ascii')
                         output.jpeg = decodebytes(output.jpeg)
     return nb
@@ -124,9 +123,9 @@ def base64_decode(nb):
 
 def base64_encode(nb):
     """Base64 encode all bytes objects in the notebook.
-    
+
     These will be b64-encoded unicode strings
-    
+
     Note: This is never used
     """
     for ws in nb.worksheets:
@@ -166,8 +165,6 @@ class NotebookReader(object):
     def read(self, fp, **kwargs):
         """Read a notebook from a file like object"""
         nbs = fp.read()
-        if not py3compat.PY3 and not isinstance(nbs, unicode_type):
-            nbs = py3compat.str_to_unicode(nbs)
         return self.reads(nbs, **kwargs)
 
 
@@ -181,9 +178,6 @@ class NotebookWriter(object):
     def write(self, nb, fp, **kwargs):
         """Write a notebook to a file like object"""
         nbs = self.writes(nb,**kwargs)
-        if not py3compat.PY3 and not isinstance(nbs, unicode_type):
-            # this branch is likely only taken for JSON on Python 2
-            nbs = py3compat.str_to_unicode(nbs)
         return fp.write(nbs)
 
 

--- a/nbformat/v3/tests/test_json.py
+++ b/nbformat/v3/tests/test_json.py
@@ -2,7 +2,6 @@ import copy
 import json
 from unittest import TestCase
 
-from ipython_genutils.py3compat import unicode_type
 from ..._compat import decodebytes
 from ..nbjson import reads, writes
 from ..nbbase import from_dict
@@ -74,7 +73,7 @@ class TestJSON(formattest.NBFormatTest, TestCase):
                 if 'png' in output:
                     found_png = True
                     pngdata = output['png']
-                    self.assertEqual(type(pngdata), unicode_type)
+                    self.assertEqual(type(pngdata), str)
                     # test that it is valid b64 data
                     b64bytes = pngdata.encode('ascii')
                     raw_bytes = decodebytes(b64bytes)
@@ -92,7 +91,7 @@ class TestJSON(formattest.NBFormatTest, TestCase):
                 if 'jpeg' in output:
                     found_jpeg = True
                     jpegdata = output['jpeg']
-                    self.assertEqual(type(jpegdata), unicode_type)
+                    self.assertEqual(type(jpegdata), str)
                     # test that it is valid b64 data
                     b64bytes = jpegdata.encode('ascii')
                     raw_bytes = decodebytes(b64bytes)

--- a/nbformat/v3/tests/test_misc.py
+++ b/nbformat/v3/tests/test_misc.py
@@ -1,7 +1,6 @@
 import os
 from unittest import TestCase
 
-from ipython_genutils.py3compat import unicode_type
 from .. import parse_filename
 
 

--- a/nbformat/v4/nbjson.py
+++ b/nbformat/v4/nbjson.py
@@ -6,8 +6,6 @@
 import copy
 import json
 
-from ipython_genutils import py3compat
-
 from ..notebooknode import from_dict
 from .rwbase import (
     NotebookReader, NotebookWriter, rejoin_lines, split_lines, strip_transient
@@ -32,7 +30,7 @@ class JSONReader(NotebookReader):
 
     def to_notebook(self, d, **kwargs):
         """Convert a disk-format notebook dict to in-memory NotebookNode
-        
+
         handles multi-line values as strings, scrubbing of transient values, etc.
         """
         nb = from_dict(d)
@@ -55,7 +53,7 @@ class JSONWriter(NotebookWriter):
         if kwargs.pop('split_lines', True):
             nb = split_lines(nb)
         nb = strip_transient(nb)
-        return py3compat.cast_unicode_py2(json.dumps(nb, **kwargs), 'utf-8')
+        return json.dumps(nb, **kwargs)
 
 
 _reader = JSONReader()

--- a/nbformat/v4/rwbase.py
+++ b/nbformat/v4/rwbase.py
@@ -3,8 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ipython_genutils.py3compat import string_types, cast_unicode_py2
-
 def _is_json_mime(mime):
     """Is a key a JSON mime-type that should be left alone?"""
     return mime == 'application/json' or \
@@ -15,7 +13,7 @@ def _rejoin_mimebundle(data):
     for key, value in list(data.items()):
         if not _is_json_mime(key) \
         and isinstance(value, list) \
-        and all(isinstance(line, string_types) for line in value):
+        and all(isinstance(line, str) for line in value):
             data[key] = ''.join(value)
     return data
 
@@ -55,7 +53,7 @@ _non_text_split_mimes = {
 def _split_mimebundle(data):
     """Split multi-line string fields in a mimebundle (in-place)"""
     for key, value in list(data.items()):
-        if isinstance(value, string_types) and (
+        if isinstance(value, str) and (
             key.startswith('text/') or key in _non_text_split_mimes
         ):
             data[key] = value.splitlines(True)
@@ -71,7 +69,7 @@ def split_lines(nb):
     """
     for cell in nb.cells:
         source = cell.get('source', None)
-        if isinstance(source, string_types):
+        if isinstance(source, str):
             cell['source'] = source.splitlines(True)
 
         attachments = cell.get('attachments', {})
@@ -83,7 +81,7 @@ def split_lines(nb):
                 if output.output_type in {'execute_result', 'display_data'}:
                     _split_mimebundle(output.get('data', {}))
                 elif output.output_type == 'stream':
-                    if isinstance(output.text, string_types):
+                    if isinstance(output.text, str):
                         output.text = output.text.splitlines(True)
     return nb
 
@@ -110,7 +108,7 @@ class NotebookReader(object):
 
     def read(self, fp, **kwargs):
         """Read a notebook from a file like object"""
-        nbs = cast_unicode_py2(fp.read())
+        nbs = fp.read()
         return self.reads(nbs, **kwargs)
 
 
@@ -123,5 +121,5 @@ class NotebookWriter(object):
 
     def write(self, nb, fp, **kwargs):
         """Write a notebook to a file like object"""
-        nbs = cast_unicode_py2(self.writes(nb, **kwargs))
+        nbs = self.writes(nb, **kwargs)
         return fp.write(nbs)

--- a/nbformat/v4/tests/test_json.py
+++ b/nbformat/v4/tests/test_json.py
@@ -1,7 +1,6 @@
 import json
 from unittest import TestCase
 
-from ipython_genutils.py3compat import unicode_type
 from ..._compat import decodebytes
 from ..nbjson import reads, writes
 from .. import nbjson
@@ -28,7 +27,7 @@ class TestJSON(formattest.NBFormatTest, TestCase):
         # This won't differ from test_roundtrip unless the default changes
         s = writes(nb0, split_lines=True)
         self.assertEqual(nbjson.reads(s),nb0)
-    
+
     def test_splitlines(self):
         """Test splitlines in mime-bundles"""
         s = writes(nb0, split_lines=True)
@@ -73,7 +72,7 @@ class TestJSON(formattest.NBFormatTest, TestCase):
                 if 'image/png' in output.data:
                     found_png = True
                     pngdata = output.data['image/png']
-                    self.assertEqual(type(pngdata), unicode_type)
+                    self.assertEqual(type(pngdata), str)
                     # test that it is valid b64 data
                     b64bytes = pngdata.encode('ascii')
                     raw_bytes = decodebytes(b64bytes)
@@ -93,7 +92,7 @@ class TestJSON(formattest.NBFormatTest, TestCase):
                 if 'image/jpeg' in output.data:
                     found_jpeg = True
                     jpegdata = output.data['image/jpeg']
-                    self.assertEqual(type(jpegdata), unicode_type)
+                    self.assertEqual(type(jpegdata), str)
                     # test that it is valid b64 data
                     b64bytes = jpegdata.encode('ascii')
                     raw_bytes = decodebytes(b64bytes)

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,10 @@ name = 'nbformat'
 import sys
 
 v = sys.version_info
-if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
-    error = "ERROR: %s requires Python version 2.7 or 3.3 or above." % name
+if (v[0] >= 3 and v[:2] < (3,5)):
+    error = "ERROR: %s requires Python version 3.5 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
-
-PY3 = (sys.version_info[0] >= 3)
 
 #-----------------------------------------------------------------------------
 # get on with it
@@ -77,9 +75,11 @@ setup_args = dict(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )
 


### PR DESCRIPTION
Addresses https://github.com/jupyter/nbformat/issues/150. The changes in the PR are documentation, setup.py, and anything that was obviously safe to change for python 3 only support (`py3compat` imports that had no logic associated). 

I left the actual version bump out of the PR direct but added the bumpversion instructions to the `RELEASING.md` file that I will execute once this merges.

nbform schema bumps to 4.5.0 with this release. The changes included some schema changes so it warrants a bump.

Apologies my editor cleaned up some file's whitespacing so the diff is longer.