### PR TITLE
Allow notebook format version 4.1 mimebundle keys ending in `+json` to have arbitrary JSON

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@
 Changes in nbformat
 =========================
 
+In Development
+==============
+
+- Allow notebook format 4.1 to have the arbitrary JSON mimebundles from format 4.2 for pragmatic purposes.
+
 5.0.4
 =====
 
@@ -35,7 +40,7 @@ Changes in nbformat
 - Link to json schema docs from format page added
 - Documented the editable metadata flag
 - Update description for collapsed field
-- Documented nbformat versions 4.0-4.3 with accurate json schema specification files
+- Documented notebook format versions 4.0-4.3 with accurate json schema specification files
 - Clarified info about :ref:`name`'s meaning for cells
 - Added a default execution_count of None for new_output_cell('execute_result')
 - Added support for handling nbjson kwargs

--- a/nbformat/v4/nbformat.v4.1.schema.json
+++ b/nbformat/v4/nbformat.v4.1.schema.json
@@ -351,16 +351,13 @@
             "mimebundle": {
                 "description": "A mime-type keyed dictionary of data",
                 "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "application/json": {
-                        "type": "object"
-                    }
+                "additionalProperties": {
+                  "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
+                  "$ref": "#/definitions/misc/multiline_string"
                 },
                 "patternProperties": {
-                    "^(?!application/json$)[a-zA-Z0-9]+/[a-zA-Z0-9\\-\\+\\.]+$": {
-                        "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
-                        "$ref": "#/definitions/misc/multiline_string"
+                    "^application/(.*\\+)?json$": {
+                        "description": "Mimetypes with JSON output, can be any type"
                     }
                 }
             },


### PR DESCRIPTION
There are a number of people posting issues with nbformat 5 being stricter about validating notebook format 4.1, including:

https://github.com/jupyter/nbformat/issues/160
https://github.com/jupyter/nbformat/issues/161
https://github.com/jupyter-widgets/ipywidgets/issues/2553
https://github.com/jupyter-widgets/ipywidgets/issues/2788


Essentially, nbformat package version 4.x allowed noncompliant format 4.1 notebooks to be verified as valid, leading to many notebooks in the wild having major/minor format version 4.1, but with widgets and other json outputs that were technically invalid.

Upgrading to nbformat package 5.x correctly flagged these notebook as noncompliant. This is correct technically. However, practically it means that all these notebooks files tagged as format 4.1 that were working fine suddenly won't even open after upgrading to nbformat version 5. This is a pain.

This retroactively upgrades the format 4.1 schema to allow json in these cases, since in practice there are lots of notebooks labeled as format 4.1, I think by official Jupyter software, that have json in the mimebundle output. Essentially, this acknowledges that in the official implementations from Jupyter, notebook format 4.1 has indeed had arbitrary JSON values in mimebundles, and we cannot in good conscience decree it invalid.