### PR TITLE
Allow notebook format 4.0 to have arbitrary JSON in mimebundle keys ending with +json.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,8 @@ Changes in nbformat
 In Development
 ==============
 
-- Allow notebook format 4.1 to have the arbitrary JSON mimebundles from format 4.2 for pragmatic purposes.
+- Allow notebook format 4.0 and 4.1 to have the arbitrary JSON mimebundles
+  from format 4.2 for pragmatic purposes.
 
 5.0.4
 =====

--- a/nbformat/v4/nbformat.v4.0.schema.json
+++ b/nbformat/v4/nbformat.v4.0.schema.json
@@ -339,16 +339,13 @@
             "mimebundle": {
                 "description": "A mime-type keyed dictionary of data",
                 "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "application/json": {
-                        "type": "object"
-                    }
+                "additionalProperties": {
+                  "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
+                  "$ref": "#/definitions/misc/multiline_string"
                 },
                 "patternProperties": {
-                    "^(?!application/json$)[a-zA-Z0-9]+/[a-zA-Z0-9\\-\\+\\.]+$": {
-                        "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
-                        "$ref": "#/definitions/misc/multiline_string"
+                    "^application/(.*\\+)?json$": {
+                        "description": "Mimetypes with JSON output, can be any type"
                     }
                 }
             },


### PR DESCRIPTION
See https://github.com/jupyter/nbformat/pull/167 for more discussion. Essentially, there are a lot of notebooks in the wild that have arbitrary JSON in the mimebundles (for example, from ipywidgets), and we never flagged them before, but with nbformat package 5, they are now suddenly they are flagged as noncompliant.

This is a follow-up to https://github.com/jupyter/nbformat/pull/167, and extends the compatibility changes from 4.1 back to 4.0.