### PR TITLE
Backport attachments to notebook format 4.0.

### DIFF
--- a/nbformat/v4/nbformat.v4.0.schema.json
+++ b/nbformat/v4/nbformat.v4.0.schema.json
@@ -113,6 +113,7 @@
                         "tags": {"$ref": "#/definitions/misc/metadata_tags"}
                     }
                 },
+                "attachments": {"$ref": "#/definitions/misc/attachments"},
                 "source": {"$ref": "#/definitions/misc/source"}
             }
         },
@@ -136,6 +137,7 @@
                     },
                     "additionalProperties": true
                 },
+                "attachments": {"$ref": "#/definitions/misc/attachments"},
                 "source": {"$ref": "#/definitions/misc/source"}
             }
         },
@@ -325,6 +327,16 @@
                 "items": {
                     "type": "string",
                     "pattern": "^[^,]+$"
+                }
+            },
+            "attachments": {
+                "description": "Media attachments (e.g. inline images), stored as mimebundle keyed by filename.",
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "description": "The attachment's data stored as a mimebundle.",
+                        "$ref": "#/definitions/misc/mimebundle"
+                    }
                 }
             },
             "source": {


### PR DESCRIPTION
See https://github.com/jupyter/nbformat/issues/170 for the reasoning. Basically, our validation was not strict enough, leading to notebooks that could have validated, but were claiming format version 4.0 and having attachments. For pragmatic reasons, we decided that the 4.0 format should retroactively be updated.

This essentially makes notebook format spec 4.0 and 4.1 identical.