### PR TITLE
Support reading/writing path-like objects

### DIFF
--- a/nbformat/__init__.py
+++ b/nbformat/__init__.py
@@ -133,11 +133,12 @@ def read(fp, as_version, **kwargs):
     nb : NotebookNode
         The notebook that was read.
     """
-    if isinstance(fp, (str, bytes)):
-        with io.open(fp, encoding='utf-8') as f:
-            return read(f, as_version, **kwargs)
 
-    return reads(fp.read(), as_version, **kwargs)
+    try:
+        return reads(fp.read(), as_version, **kwargs)
+    except AttributeError:
+        with io.open(fp, encoding='utf-8') as f:
+            return reads(f.read(), as_version, **kwargs)
 
 
 def write(nb, fp, version=NO_CONVERT, **kwargs):
@@ -158,13 +159,16 @@ def write(nb, fp, version=NO_CONVERT, **kwargs):
         If unspecified, or specified as nbformat.NO_CONVERT,
         the notebook's own version will be used and no conversion performed.
     """
-    if isinstance(fp, (str, bytes)):
-        with io.open(fp, 'w', encoding='utf-8') as f:
-            return write(nb, f, version=version, **kwargs)
-
     s = writes(nb, version, **kwargs)
     if isinstance(s, bytes):
         s = s.decode('utf8')
-    fp.write(s)
-    if not s.endswith(u'\n'):
-        fp.write(u'\n')
+
+    try:
+        fp.write(s)
+        if not s.endswith(u'\n'):
+            fp.write(u'\n')
+    except AttributeError:
+        with io.open(fp, 'w', encoding='utf-8') as f:
+            f.write(s)
+            if not s.endswith(u'\n'):
+                f.write(u'\n')

--- a/nbformat/tests/test_api.py
+++ b/nbformat/tests/test_api.py
@@ -5,6 +5,9 @@
 
 import json
 import os
+import pathlib
+import sys
+import unittest
 
 from .base import TestsBase
 
@@ -45,5 +48,19 @@ class TestAPI(TestsBase):
 
         with TemporaryDirectory() as td:
             dest = os.path.join(td, 'echidna.ipynb')
+            write(nb, dest)
+            assert os.path.isfile(dest)
+
+    @unittest.skipIf(
+        sys.version_info < (3, 6, 0),
+        "python versions 3.5 and lower don't support opening pathlib.Path objects"
+    )
+    def test_read_write_pathlib_object(self):
+        """read() and write() take path-like objects such as pathlib objects"""
+        path = pathlib.Path(self._get_files_path()) / u'test4.ipynb'
+        nb = read(path, as_version=4)
+
+        with TemporaryDirectory() as td:
+            dest = pathlib.Path(td) / 'echidna.ipynb'
             write(nb, dest)
             assert os.path.isfile(dest)


### PR DESCRIPTION
Switching this to a try/except model seems to follow the python 'duck-typing' ethos -- i don't really care about the type of `fp`, i only care what i can do with it:

1. I'll try reading/writing (supports any file-like object)
2.  if step 1 that doesn't work, i'll try opening fp and *then* reading / writing (supports any path-like object that can be opened)

i tried this out locally and it seemed to work both with a `Path` object and a string containing the path 


fixes #147 