### PR TITLE
Fix backward compatibility of an error handling

### DIFF
--- a/nbformat/__init__.py
+++ b/nbformat/__init__.py
@@ -135,13 +135,12 @@ def read(fp, as_version, **kwargs):
     """
 
     try:
-        return reads(fp.read(), as_version, **kwargs)
+        buf = fp.read()
     except AttributeError:
-        if hasattr(fp, "read") and callable(getattr(fp, "read")):
-            raise
-
         with io.open(fp, encoding='utf-8') as f:
             return reads(f.read(), as_version, **kwargs)
+
+    return reads(buf, as_version, **kwargs)
 
 
 def write(nb, fp, version=NO_CONVERT, **kwargs):

--- a/nbformat/__init__.py
+++ b/nbformat/__init__.py
@@ -137,6 +137,9 @@ def read(fp, as_version, **kwargs):
     try:
         return reads(fp.read(), as_version, **kwargs)
     except AttributeError:
+        if hasattr(fp, "read") and callable(getattr(fp, "read")):
+            raise
+
         with io.open(fp, encoding='utf-8') as f:
             return reads(f.read(), as_version, **kwargs)
 

--- a/nbformat/tests/test_nbformat.py
+++ b/nbformat/tests/test_nbformat.py
@@ -40,4 +40,3 @@ def test_read_invalid_str(tmpdir):
 def test_read_invalid_type(tmpdir):
     with pytest.raises(OSError) as excinfo:
         read(123, as_version=4)
-    assert "Bad file descriptor" in str(excinfo.value)

--- a/nbformat/tests/test_nbformat.py
+++ b/nbformat/tests/test_nbformat.py
@@ -8,7 +8,7 @@ def test_read_invalid_iowrapper(tmpdir):
     config_filepath.write("{}")
 
     with pytest.raises(AttributeError) as excinfo:
-        with open(config_filepath) as fp:
+        with config_filepath.open() as fp:
             read(fp, as_version=4)
     assert "cells" in str(excinfo.value)
 

--- a/nbformat/tests/test_nbformat.py
+++ b/nbformat/tests/test_nbformat.py
@@ -4,30 +4,30 @@ from nbformat import read
 
 
 def test_read_invalid_iowrapper(tmpdir):
-    config_filepath = tmpdir.join("empty.ipynb")
-    config_filepath.write("{}")
+    ipynb_filepath = tmpdir.join("empty.ipynb")
+    ipynb_filepath.write("{}")
 
     with pytest.raises(AttributeError) as excinfo:
-        with config_filepath.open() as fp:
+        with ipynb_filepath.open() as fp:
             read(fp, as_version=4)
     assert "cells" in str(excinfo.value)
 
 
 def test_read_invalid_filepath(tmpdir):
-    config_filepath = tmpdir.join("empty.ipynb")
-    config_filepath.write("{}")
+    ipynb_filepath = tmpdir.join("empty.ipynb")
+    ipynb_filepath.write("{}")
 
     with pytest.raises(AttributeError) as excinfo:
-        read(str(config_filepath), as_version=4)
+        read(str(ipynb_filepath), as_version=4)
     assert "cells" in str(excinfo.value)
 
 
 def test_read_invalid_pathlikeobj(tmpdir):
-    config_filepath = tmpdir.join("empty.ipynb")
-    config_filepath.write("{}")
+    ipynb_filepath = tmpdir.join("empty.ipynb")
+    ipynb_filepath.write("{}")
 
     with pytest.raises(AttributeError) as excinfo:
-        read(config_filepath, as_version=4)
+        read(ipynb_filepath, as_version=4)
     assert "cells" in str(excinfo.value)
 
 

--- a/nbformat/tests/test_nbformat.py
+++ b/nbformat/tests/test_nbformat.py
@@ -1,0 +1,43 @@
+import pytest
+
+from nbformat import read
+
+
+def test_read_invalid_iowrapper(tmpdir):
+    config_filepath = tmpdir.join("empty.ipynb")
+    config_filepath.write("{}")
+
+    with pytest.raises(AttributeError) as excinfo:
+        with open(config_filepath) as fp:
+            read(fp, as_version=4)
+    assert "cells" in str(excinfo.value)
+
+
+def test_read_invalid_filepath(tmpdir):
+    config_filepath = tmpdir.join("empty.ipynb")
+    config_filepath.write("{}")
+
+    with pytest.raises(AttributeError) as excinfo:
+        read(str(config_filepath), as_version=4)
+    assert "cells" in str(excinfo.value)
+
+
+def test_read_invalid_pathlikeobj(tmpdir):
+    config_filepath = tmpdir.join("empty.ipynb")
+    config_filepath.write("{}")
+
+    with pytest.raises(AttributeError) as excinfo:
+        read(config_filepath, as_version=4)
+    assert "cells" in str(excinfo.value)
+
+
+def test_read_invalid_str(tmpdir):
+    with pytest.raises(OSError) as excinfo:
+        read("not_exist_path", as_version=4)
+    assert "No such file or directory" in str(excinfo.value)
+
+
+def test_read_invalid_type(tmpdir):
+    with pytest.raises(OSError) as excinfo:
+        read(123, as_version=4)
+    assert "Bad file descriptor" in str(excinfo.value)


### PR DESCRIPTION
This PR aims to fix backward compatibility of an error handling.

At `nbformat 5.0.5`, `nbformat.read` method raises `TypeError` that is a different exception from `nbformat 5.0.4` or older (`AttributeError`) when executing the method with an invalid notebook file.

The following source code can reproduce the issue:

```py
import nbformat

ipynb_file = "empty.ipynb"

with open(ipynb_file, "w") as fp:
    fp.write("{}")

with open(ipynb_file) as fp:
    nbformat.read(fp, as_version=4)
```

Until `nbformat 5.0.4` or older versions, this results `AttributeError`.

    ...
    .../ipython_genutils/ipstruct.py", line 134, in __getattr__
        raise AttributeError(key)

However, `nbformat 5.0.5` will raise `TypeError`:

    ...
    .../nbformat/__init__.py", line 140, in read
        with io.open(fp, encoding='utf-8') as f:
    TypeError: expected str, bytes or os.PathLike object, not _io.TextIOWrapper

This occurred by the #173 change.
`AttributeError` may raise by `reads` method call at:

https://github.com/jupyter/nbformat/blob/7a407244a3885877175df04446600b98935799e1/nbformat/__init__.py#L138

even when passing a file descriptor to `read` method.