### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -95,9 +95,9 @@ class TestValidator(TestsBase):
         with self.assertRaises(ValidationError) as e:
             validate(nb)
         s = str(e.exception)
-        self.assertRegexpMatches(s, "validating.*required.* in markdown_cell")
-        self.assertRegexpMatches(s, "source.* is a required property")
-        self.assertRegexpMatches(s, r"On instance\[u?['\"].*cells['\"]\]\[0\]")
+        self.assertRegex(s, "validating.*required.* in markdown_cell")
+        self.assertRegex(s, "source.* is a required property")
+        self.assertRegex(s, r"On instance\[u?['\"].*cells['\"]\]\[0\]")
         self.assertLess(len(s.splitlines()), 10)
 
     def test_iter_validation_error(self):


### PR DESCRIPTION
I got the following DeprecationWarning in Python 3.5+ when running tests.

```
py::TestValidator::test_validation_error
  .../nbformat/nbformat/tests/test_validator.py:98: DeprecationWarning: Please use assertRegex instead.
    self.assertRegexpMatches(s, "validating.*required.* in markdown_cell")

nbformat/tests/test_validator.py::TestValidator::test_validation_error
  .../nbformat/nbformat/tests/test_validator.py:99: DeprecationWarning: Please use assertRegex instead.
    self.assertRegexpMatches(s, "source.* is a required property")

nbformat/tests/test_validator.py::TestValidator::test_validation_error
  .../nbformat/nbformat/tests/test_validator.py:100: DeprecationWarning: Please use assertRegex instead.
    self.assertRegexpMatches(s, r"On instance\[u?['\"].*cells['\"]\]\[0\]")
```

This PR will fix these warnings.