### PR TITLE
Fix get_validator()

### DIFF
--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -54,7 +54,7 @@ def _allow_undefined(schema):
 def get_validator(version=None, version_minor=None, relax_add_props=False):
     """Load the JSON schema into a Validator"""
     if version is None:
-        from .. import current_nbformat
+        from . import current_nbformat
         version = current_nbformat
 
     v = import_item("nbformat.v%s" % version)


### PR DESCRIPTION
Attempting to call `get_validator()` without arguments led to an ImportError:

```
In [1]: from nbformat.validator import get_validator
In [2]: get_validator()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-0ba64c184823> in <module>
----> 1 get_validator()

~/nbformat/nbformat/validator.py in get_validator(version, version_minor, relax_add_props)
     55     """Load the JSON schema into a Validator"""
     56     if version is None:
---> 57         from .. import current_nbformat
     58         version = current_nbformat
     59

ValueError: attempted relative import beyond top-level package
```

This fixes that bug

```
In [1]: from nbformat.validator import get_validator
In [2]: get_validator()
Out[2]: <jsonschema.validators.create.<locals>.Validator at 0x108a95b90>
```