### PR TITLE
Fix exception cause in reader.py

### DIFF
--- a/nbformat/reader.py
+++ b/nbformat/reader.py
@@ -12,9 +12,9 @@ def parse_json(s, **kwargs):
     """Parse a JSON string into a dict."""
     try:
         nb_dict = json.loads(s, **kwargs)
-    except ValueError:
+    except ValueError as e:
         # Limit the error message to 80 characters.  Display whatever JSON will fit.
-        raise NotJSONError(("Notebook does not appear to be JSON: %r" % s)[:77] + "...")
+        raise NotJSONError(("Notebook does not appear to be JSON: %r" % s)[:77] + "...") from e
     return nb_dict
 
 # High level API


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now, there is one other file with this issue.

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 