### PR TITLE
PR: Use fastjsonschema if installed and add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Install test dependencies
       run: |
         pip install --upgrade pip setuptools
-        pip install nbformat[test]
-        pip install nbformat[fast]
+        pip install .[test]
+        pip install .[fast]
         pip install codecov
     - name: Install nbformat
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ jobs:
       run: |
         pip install --upgrade pip setuptools
         pip install .[test]
-        pip install .[fast]
         pip install codecov
     - name: Install nbformat
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         pip install --upgrade pip setuptools
         pip install nbformat[test]
+        pip install nbformat[fast]
         pip install codecov
     - name: Install nbformat
       run: |

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![codecov.io](https://codecov.io/github/jupyter/nbformat/coverage.svg?branch=master)](https://codecov.io/github/jupyter/nbformat?branch=master)
 [![Code Health](https://landscape.io/github/jupyter/nbformat/master/landscape.svg?style=flat)](https://landscape.io/github/jupyter/nbformat/master)
-
-
+![CI Tests](https://github.com/jupyter/nbformat/workflows/Run%20tests/badge.svg)
 
 `nbformat` contains the reference implementation of the [Jupyter Notebook format][],
 and Python APIs for working with notebooks.
@@ -19,6 +18,16 @@ From the command line:
 ``` {.sourceCode .bash}
 pip install nbformat
 ```
+
+## Using a different json schema validator
+
+You can install and use [fastjsonschema](https://horejsek.github.io/python-fastjsonschema/) by running:
+
+``` {.sourceCode .bash}
+pip install nbformat[fast]
+```
+
+To enable fast validation with `fastjsonschema`, set the environment variable `NBFORMAT_VALIDATOR` to the value `fastjsonschema`.
 
 ## Python Version Support
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -120,3 +120,15 @@ bindings are available, and an in-memory store otherwise.
 .. autoclass:: SQLiteSignatureStore
 
 .. autoclass:: MemorySignatureStore
+
+Optional fast validation
+------------------------
+
+You can install and use `fastjsonschema <https://horejsek.github.io/python-fastjsonschema/>`_ by running::
+
+    pip install nbformat[fast]
+
+
+To enable fast validation with `fastjsonschema`, set the environment variable::
+
+   NBFORMAT_VALIDATOR="fastjsonschema"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,10 @@ Changes in nbformat
 In Development
 ==============
 
+- Add optional support for using `fastjsonschema` as the JSON validation library.
+  To enable fast validation, install `fastjsonschema` and set the environment
+  variable `NBFORMAT_VALIDATOR` to the value `fastjsonschema`.
+
 5.0.7
 =====
 

--- a/nbformat/__init__.py
+++ b/nbformat/__init__.py
@@ -74,7 +74,7 @@ def reads(s, as_version, **kwargs):
     if as_version is not NO_CONVERT:
         nb = convert(nb, as_version)
     try:
-        validate(nb)
+        validate(nb, use_fast=True)
     except ValidationError as e:
         get_logger().error("Notebook JSON is invalid: %s", e)
     return nb
@@ -104,7 +104,7 @@ def writes(nb, version=NO_CONVERT, **kwargs):
     else:
         version, _ = reader.get_version(nb)
     try:
-        validate(nb)
+        validate(nb, use_fast=True)
     except ValidationError as e:
         get_logger().error("Notebook JSON is invalid: %s", e)
     return versions[version].writes_json(nb, **kwargs)

--- a/nbformat/__init__.py
+++ b/nbformat/__init__.py
@@ -74,7 +74,7 @@ def reads(s, as_version, **kwargs):
     if as_version is not NO_CONVERT:
         nb = convert(nb, as_version)
     try:
-        validate(nb, use_fast=True)
+        validate(nb)
     except ValidationError as e:
         get_logger().error("Notebook JSON is invalid: %s", e)
     return nb
@@ -104,7 +104,7 @@ def writes(nb, version=NO_CONVERT, **kwargs):
     else:
         version, _ = reader.get_version(nb)
     try:
-        validate(nb, use_fast=True)
+        validate(nb)
     except ValidationError as e:
         get_logger().error("Notebook JSON is invalid: %s", e)
     return versions[version].writes_json(nb, **kwargs)

--- a/nbformat/json_compat.py
+++ b/nbformat/json_compat.py
@@ -5,6 +5,9 @@ Common validator wrapper to provide a uniform usage of other schema validation
 libraries.
 """
 
+import os
+
+import jsonschema
 from jsonschema import Draft4Validator as _JsonSchemaValidator
 from jsonschema import ValidationError
 
@@ -16,32 +19,56 @@ except ImportError:
     _JsonSchemaException = ValidationError
 
 
-class Validator:
-    """
-    Common validator wrapper to provide a uniform usage of other schema validation
-    libraries.
-    """
+class JsonSchemaValidator:
+    name = "jsonschema"
 
     def __init__(self, schema):
         self._schema = schema
-
-        # Validation libraries
-        self._jsonschema = _JsonSchemaValidator(schema)  # Default
-        self._fastjsonschema_validate = fastjsonschema.compile(schema) if fastjsonschema else None
+        self._default_validator = _JsonSchemaValidator(schema)  # Default
+        self._validator = self._default_validator
 
     def validate(self, data):
-        """
-        Validate the schema of ``data``.
-
-        Will use ``fastjsonschema`` if available.
-        """
-        if fastjsonschema:
-            try:
-                self._fastjsonschema_validate(data)
-            except _JsonSchemaException as e:
-                raise ValidationError(e.message)
-        else:
-            self._jsonschema.validate(data)
+        self._default_validator.validate(data)
 
     def iter_errors(self, data, schema=None):
-        return self._jsonschema.iter_errors(data, schema)
+        return self._default_validator.iter_errors(data, schema)
+
+
+class FastJsonSchemaValidator(JsonSchemaValidator):
+    name = "fastjsonschema"
+
+    def __init__(self, schema):
+        super().__init__(schema)
+
+        self._validator = fastjsonschema.compile(schema)
+
+    def validate(self, data):
+        try:
+            self._validator(data)
+        except _JsonSchemaException as error:
+            raise ValidationError(error.message, schema_path=error.path)
+
+
+_VALIDATOR_MAP = [
+    ("fastjsonschema", fastjsonschema, FastJsonSchemaValidator),
+    ("jsonschema", jsonschema, JsonSchemaValidator),
+]
+VALIDATORS = [item[0] for item in _VALIDATOR_MAP]
+
+
+def _validator_for_name(validator_name):
+    if validator_name not in VALIDATORS:
+        raise ValueError("Invalid validator '{0}' value!\nValid values are: {1}".format(
+            validator_name, VALIDATORS))
+
+    for (name, module, validator_cls) in _VALIDATOR_MAP:
+        if module and validator_name == name:
+            return validator_cls
+
+
+def get_current_validator():
+    """
+    Return the current validator based on the value of an environment variable.
+    """
+    validator_name = os.environ.get("NBFORMAT_VALIDATOR", "jsonschema")
+    return _validator_for_name(validator_name)

--- a/nbformat/json_compat.py
+++ b/nbformat/json_compat.py
@@ -1,0 +1,47 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""
+Common validator wrapper to provide a uniform usage of other schema validation
+libraries.
+"""
+
+from jsonschema import Draft4Validator as _JsonSchemaValidator
+from jsonschema import ValidationError
+
+try:
+    import fastjsonschema
+    from fastjsonschema import JsonSchemaException as _JsonSchemaException
+except ImportError:
+    fastjsonschema = None
+    _JsonSchemaException = ValidationError
+
+
+class Validator:
+    """
+    Common validator wrapper to provide a uniform usage of other schema validation
+    libraries.
+    """
+
+    def __init__(self, schema):
+        self._schema = schema
+
+        # Validation libraries
+        self._jsonschema = _JsonSchemaValidator(schema)  # Default
+        self._fastjsonschema_validate = fastjsonschema.compile(schema) if fastjsonschema else None
+
+    def validate(self, data):
+        """
+        Validate the schema of ``data``.
+
+        Will use ``fastjsonschema`` if available.
+        """
+        if fastjsonschema:
+            try:
+                self._fastjsonschema_validate(data)
+            except _JsonSchemaException as e:
+                raise ValidationError(e.message)
+        else:
+            self._jsonschema.validate(data)
+
+    def iter_errors(self, data, schema=None):
+        return self._jsonschema.iter_errors(data, schema)

--- a/nbformat/tests/base.py
+++ b/nbformat/tests/base.py
@@ -12,9 +12,10 @@ import io
 class TestsBase(unittest.TestCase):
     """Base tests class."""
 
-    def fopen(self, f, mode=u'r',encoding='utf-8'):
-        return io.open(os.path.join(self._get_files_path(), f), mode, encoding=encoding)
+    @classmethod
+    def fopen(cls, f, mode=u'r',encoding='utf-8'):
+        return io.open(os.path.join(cls._get_files_path(), f), mode, encoding=encoding)
 
-
-    def _get_files_path(self):
+    @classmethod
+    def _get_files_path(cls):
         return os.path.dirname(__file__)

--- a/nbformat/tests/many_tracebacks.ipynb
+++ b/nbformat/tests/many_tracebacks.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'iAmNotDefined' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-22-56e1109ae320>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0miAmNotDefined\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'iAmNotDefined' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "# Imagine this cell called a function which runs things on a cluster and you have an error"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -4,147 +4,196 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-import time
+import re
 
 from .base import TestsBase
 from jsonschema import ValidationError
 from nbformat import read
 from ..validator import isvalid, validate, iter_validate
+from ..json_compat import VALIDATORS
 
-try:
-    import fastjsonschema
-except ImportError:
-    fastjsonschema = None
+import pytest
 
 
-class TestValidator(TestsBase):
+# Fixtures
+@pytest.fixture(autouse=True)
+def clean_env_before_and_after_tests():
+    """Fixture to clean up env variables before and after tests."""
+    os.environ.pop("NBFORMAT_VALIDATOR", None)
+    yield
+    os.environ.pop("NBFORMAT_VALIDATOR", None)
 
-    def test_nb2(self):
-        """Test that a v2 notebook converted to current passes validation"""
-        with self.fopen(u'test2.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
+
+# Helpers
+def set_validator(validator_name):
+    os.environ["NBFORMAT_VALIDATOR"] = validator_name
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_nb2(validator_name):
+    """Test that a v2 notebook converted to current passes validation"""
+    set_validator(validator_name)
+    with TestsBase.fopen(u'test2.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    validate(nb)
+    assert isvalid(nb) == True
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_nb3(validator_name):
+    """Test that a v3 notebook passes validation"""
+    set_validator(validator_name)
+    with TestsBase.fopen(u'test3.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    validate(nb)
+    assert isvalid(nb) == True
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_nb4(validator_name):
+    """Test that a v4 notebook passes validation"""
+    set_validator(validator_name)
+    with TestsBase.fopen(u'test4.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    validate(nb)
+    assert isvalid(nb) == True
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_nb4_document_info(validator_name):
+    """Test that a notebook with document_info passes validation"""
+    set_validator(validator_name)
+    with TestsBase.fopen(u'test4docinfo.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    validate(nb)
+    assert isvalid(nb)
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_nb4custom(validator_name):
+    """Test that a notebook with a custom JSON mimetype passes validation"""
+    set_validator(validator_name)
+    with TestsBase.fopen(u'test4custom.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    validate(nb)
+    assert isvalid(nb)
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_nb4jupyter_metadata(validator_name):
+    """Test that a notebook with a jupyter metadata passes validation"""
+    set_validator(validator_name)
+    with TestsBase.fopen(u'test4jupyter_metadata.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    validate(nb)
+    assert isvalid(nb)
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_nb4jupyter_metadata_timings(validator_name):
+    """Tests that a notebook with "timing" in metadata passes validation"""
+    set_validator(validator_name)
+    with TestsBase.fopen(u'test4jupyter_metadata_timings.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    validate(nb)
+    assert isvalid(nb)
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_invalid(validator_name):
+    """Test than an invalid notebook does not pass validation"""
+    set_validator(validator_name)
+    # this notebook has a few different errors:
+    # - one cell is missing its source
+    # - invalid cell type
+    # - invalid output_type
+    with TestsBase.fopen(u'invalid.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    with pytest.raises(ValidationError):
         validate(nb)
-        self.assertEqual(isvalid(nb), True)
+    assert not isvalid(nb)
 
-    def test_nb3(self):
-        """Test that a v3 notebook passes validation"""
-        with self.fopen(u'test3.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_validate_empty(validator_name):
+    """Test that an empty notebook (invalid) fails validation"""
+    set_validator(validator_name)
+    with pytest.raises(ValidationError) as e:
+        validate({})
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_future(validator_name):
+    """Test that a notebook from the future with extra keys passes validation"""
+    set_validator(validator_name)
+    with TestsBase.fopen(u'test4plus.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    with pytest.raises(ValidationError):
+        validate(nb, version=4, version_minor=3)
+
+    assert not isvalid(nb, version=4, version_minor=3)
+    assert isvalid(nb)
+
+
+# This is only a valid test for the default validator, jsonschema
+@pytest.mark.parametrize("validator_name", ["jsonschema"])
+def test_validation_error(validator_name):
+    set_validator(validator_name)
+    with TestsBase.fopen(u'invalid.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+    with pytest.raises(ValidationError) as exception_info:
         validate(nb)
-        self.assertEqual(isvalid(nb), True)
 
-    def test_nb4(self):
-        """Test that a v4 notebook passes validation"""
-        with self.fopen(u'test4.ipynb', u'r') as f:
+    s = str(exception_info.value)
+    assert re.compile(r"validating .required. in markdown_cell").search(s)
+    assert re.compile(r"source.* is a required property").search(s)
+    assert re.compile(r"On instance\[u?['\"].*cells['\"]\]\[0\]").search(s)
+    assert len(s.splitlines()) < 10
+
+
+# This is only a valid test for the default validator, jsonschema
+@pytest.mark.parametrize("validator_name", ["jsonschema"])
+def test_iter_validation_error(validator_name):
+    set_validator(validator_name)
+    with TestsBase.fopen(u'invalid.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+
+    errors = list(iter_validate(nb))
+    assert len(errors) == 3
+    assert {e.ref for e in errors} == {'markdown_cell', 'heading_cell', 'bad stream'}
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_iter_validation_empty(validator_name):
+    """Test that an empty notebook (invalid) fails validation via iter_validate"""
+    set_validator(validator_name)
+    errors = list(iter_validate({}))
+    assert len(errors) == 1
+    assert type(errors[0]) == ValidationError
+
+
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_validation_no_version(validator_name):
+    """Test that an invalid notebook with no version fails validation"""
+    set_validator(validator_name)
+    with pytest.raises(ValidationError) as e:
+        validate({'invalid': 'notebook'})
+
+
+def test_invalid_validator_raises_value_error():
+    """Test that an invalid notebook with no version fails validation"""
+    set_validator("foobar")
+    with pytest.raises(ValueError):
+        with TestsBase.fopen(u'test2.ipynb', u'r') as f:
             nb = read(f, as_version=4)
+
+
+def test_invalid_validator_raises_value_error_after_read():
+    """Test that an invalid notebook with no version fails validation"""
+    set_validator("jsonschema")
+    with TestsBase.fopen(u'test2.ipynb', u'r') as f:
+        nb = read(f, as_version=4)
+
+    set_validator("foobar")
+    with pytest.raises(ValueError):
         validate(nb)
-        self.assertEqual(isvalid(nb), True)
-
-    def test_nb4_document_info(self):
-        """Test that a notebook with document_info passes validation"""
-        with self.fopen(u'test4docinfo.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
-        validate(nb)
-        self.assertEqual(isvalid(nb), True)
-
-    def test_nb4custom(self):
-        """Test that a notebook with a custom JSON mimetype passes validation"""
-        with self.fopen(u'test4custom.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
-        validate(nb)
-        self.assertEqual(isvalid(nb), True)
-
-    def test_nb4jupyter_metadata(self):
-        """Test that a notebook with a jupyter metadata passes validation"""
-        with self.fopen(u'test4jupyter_metadata.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
-        validate(nb)
-        self.assertEqual(isvalid(nb), True)
-
-    def test_nb4jupyter_metadata_timings(self):
-        """Tests that a notebook with "timing" in metadata passes validation"""
-        with self.fopen(u'test4jupyter_metadata_timings.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
-        validate(nb)
-        self.assertTrue(isvalid(nb))
-
-    def test_invalid(self):
-        """Test than an invalid notebook does not pass validation"""
-        # this notebook has a few different errors:
-        # - one cell is missing its source
-        # - invalid cell type
-        # - invalid output_type
-        with self.fopen(u'invalid.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
-        with self.assertRaises(ValidationError):
-            validate(nb)
-        self.assertEqual(isvalid(nb), False)
-
-    def test_validate_empty(self):
-        """Test that an empty notebook (invalid) fails validation"""
-        with self.assertRaises(ValidationError) as e:
-            validate({})
-
-    def test_future(self):
-        """Test that a notebook from the future with extra keys passes validation"""
-        with self.fopen(u'test4plus.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
-        with self.assertRaises(ValidationError):
-            validate(nb, version=4, version_minor=3)
-
-        self.assertEqual(isvalid(nb, version=4, version_minor=3), False)
-        self.assertEqual(isvalid(nb), True)
-
-    def test_validation_error(self):
-        with self.fopen(u'invalid.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
-        with self.assertRaises(ValidationError) as e:
-            validate(nb)
-        s = str(e.exception)
-        self.assertRegex(s, "validating.*required.* in markdown_cell")
-        self.assertRegex(s, "source.* is a required property")
-        self.assertRegex(s, r"On instance\[u?['\"].*cells['\"]\]\[0\]")
-        self.assertLess(len(s.splitlines()), 10)
-
-    def test_iter_validation_error(self):
-        with self.fopen(u'invalid.ipynb', u'r') as f:
-            nb = read(f, as_version=4)
-
-        errors = list(iter_validate(nb))
-        assert len(errors) == 3
-        assert {e.ref for e in errors} == {'markdown_cell', 'heading_cell', 'bad stream'}
-
-    def test_iter_validation_empty(self):
-        """Test that an empty notebook (invalid) fails validation via iter_validate"""
-        errors = list(iter_validate({}))
-        assert len(errors) == 1
-        assert type(errors[0]) == ValidationError
-
-    def test_validation_no_version(self):
-        """Test that an invalid notebook with no version fails validation"""
-        with self.assertRaises(ValidationError) as e:
-            validate({'invalid': 'notebook'})
-
-    def test_fast_validation(self):
-        """
-        Test that valid notebook with too many outputs is parsed ~12 times
-        faster with fastjsonschema.
-        """
-        if fastjsonschema:
-            with self.fopen(u'many_tracebacks.ipynb', u'r') as f:
-                nb = read(f, as_version=4)
-
-            # Multiply output
-            base_output = nb["cells"][0]["outputs"][0]
-            for i in range(50000):
-                nb["cells"][0]["outputs"].append(base_output)
-
-            start_time = time.time()
-            validate(nb, use_fast=True)
-            fast_time = time.time() - start_time
-
-            start_time = time.time()
-            validate(nb)
-            slow_time = time.time() - start_time
-
-            self.assertGreater(slow_time / fast_time, 12)

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -229,7 +229,7 @@ def better_validation_error(error, version, version_minor):
 
 
 def validate(nbdict=None, ref=None, version=None, version_minor=None,
-             relax_add_props=False, nbjson=None, use_fast=False):
+             relax_add_props=False, nbjson=None):
     """Checks whether the given notebook dict-like object
     conforms to the relevant notebook format schema.
 
@@ -245,7 +245,6 @@ def validate(nbdict=None, ref=None, version=None, version_minor=None,
     else:
         raise TypeError("validate() missing 1 required argument: 'nbdict'")
 
-
     if ref is None:
         # if ref is not specified, we have a whole notebook, so we can get the version
         nbdict_version, nbdict_version_minor = get_version(nbdict)
@@ -258,20 +257,10 @@ def validate(nbdict=None, ref=None, version=None, version_minor=None,
         if version is None:
             version, version_minor = 1, 0
 
-    validator = get_validator(version, version_minor, relax_add_props=relax_add_props)
-    if validator is None:
-        raise ValidationError("No schema for validating v%s notebooks" % version)
-    elif validator.name != "jsonschema":
-        # If not using default validator then, skip iter_validate, and provide
-        # less legible errors
-        validator.validate(nbdict)
-    else:
-        # If using default validator then use iter_validate, and provide
-        # more readable errors
-        for error in iter_validate(nbdict, ref=ref, version=version,
-                                    version_minor=version_minor,
-                                    relax_add_props=relax_add_props):
-            raise error
+    for error in iter_validate(nbdict, ref=ref, version=version,
+                               version_minor=version_minor,
+                               relax_add_props=relax_add_props):
+        raise error
 
 
 def iter_validate(nbdict=None, ref=None, version=None, version_minor=None,

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ install_requires = setuptools_args['install_requires'] = [
 
 extras_require = setuptools_args['extras_require'] = {
     'fast': ['fastjsonschema'],
-    'test': ['testpath', 'pytest', 'pytest-cov'],
+    'test': ['fastjsonschema', 'testpath', 'pytest', 'pytest-cov'],
 }
 
 if 'setuptools' in sys.modules:

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
+    'fast': ['fastjsonschema'],
     'test': ['testpath', 'pytest', 'pytest-cov'],
 }
 


### PR DESCRIPTION
Fixes #190

This adds the possibility of using [fastjsonschema](https://github.com/horejsek/python-fastjsonschema/) if installed and other libraries if installed or defined by a `NBFORMAT_VALIDATOR` environment variable.

The possible values are 1-1 to the module names so, `jsonschema`, `fastjsonschema`, eventually (when stable) we could also add `jsonschema_rs`, the rust implementation.

- Added a tests to check things work as expected with both libraries, with one caveat: test that expect a `better_error` will not work, so those 2 tests are skipped for `fastjsonschema`. The rest works as expected. This means if using `fastjsonschema` printed errors will be less readable.
- Update CI configuration.
- Used pytest parametrize

Related to https://github.com/jupyter/jupyter_server/issues/312

Pinging @echarles, @jasongrout, @Zsailer, @mlucool