### PR TITLE
PR: Fallback to default validator if subschema is provided

### DIFF
--- a/nbformat/json_compat.py
+++ b/nbformat/json_compat.py
@@ -38,6 +38,7 @@ class FastJsonSchemaValidator(JsonSchemaValidator):
     name = "fastjsonschema"
 
     def __init__(self, schema):
+        super().__init__(schema)
         self._validator = fastjsonschema.compile(schema)
 
     def validate(self, data):
@@ -47,6 +48,9 @@ class FastJsonSchemaValidator(JsonSchemaValidator):
             raise ValidationError(error.message, schema_path=error.path)
 
     def iter_errors(self, data, schema=None):
+        if schema is not None:
+            return self._default_validator.iter_errors(data, schema)
+
         errors = []
         validate_func = self._validator if schema is None else fastjsonschema.compile(schema)
         try:

--- a/nbformat/json_compat.py
+++ b/nbformat/json_compat.py
@@ -52,7 +52,7 @@ class FastJsonSchemaValidator(JsonSchemaValidator):
             return self._default_validator.iter_errors(data, schema)
 
         errors = []
-        validate_func = self._validator if schema is None else fastjsonschema.compile(schema)
+        validate_func = self._validator
         try:
             validate_func(data)
         except _JsonSchemaException as error:

--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -197,3 +197,15 @@ def test_invalid_validator_raises_value_error_after_read():
     set_validator("foobar")
     with pytest.raises(ValueError):
         validate(nb)
+
+
+def test_fallback_validator_with_iter_errors_using_ref():
+    """
+    Test that when creating a standalone object (code_cell etc)
+    the default validator is used as fallback.
+    """
+    import nbformat
+    set_validator("fastjsonschema")
+    nbformat.v4.new_code_cell()
+    nbformat.v4.new_markdown_cell()
+    nbformat.v4.new_raw_cell()


### PR DESCRIPTION
Fixes #197 

This fixes a regression introduced when using fastjsonschema, which does not directly support to validate a "reference"/"subschema". For these cases, `iter_errors`  falls back to the default validator that uses json schema.



