### PR TITLE
Fix installing package_data when --build-base is set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,17 @@ for d, _, _ in os.walk(pjoin(here, name)):
         packages.append(d[len(here)+1:].replace(os.path.sep, '.'))
 
 package_data = {
-    'nbformat' : [
-        'corpus/*.txt'
-        'tests/*.ipynb',
-        'v3/nbformat.v3*.schema.json',
-        'v4/nbformat.v4*.schema.json',
+    'nbformat.corpus' : [
+        '*.txt',
+    ],
+    'nbformat.tests' : [
+        '*.ipynb',
+    ],
+    'nbformat.v3' : [
+        'nbformat.v3*.schema.json',
+    ],
+    'nbformat.v4' : [
+        'nbformat.v4*.schema.json',
     ],
 }
 


### PR DESCRIPTION
Fix package_data declarations in setup.py to associate every set
of files with its bottommost package.  This is necessary for the 'build'
command to install files correctly when --build-base is passed
explicitly.  The all-files-for-top-package approach seems to work only
incidentally.

To reproduce the problem, try:

    setup.py build --build-base=build2

and note that none of the data files were installed.