### PR TITLE
Store words in a list (rather than in a set)

### DIFF
--- a/nbformat/corpus/tests/test_words.py
+++ b/nbformat/corpus/tests/test_words.py
@@ -8,8 +8,10 @@ import random
 
 from .. import words
 
+
 def test_acceptable_nouns_set():
     assert len(words.acceptable_nouns()) > 1000
+    assert len(words.acceptable_nouns()) == len(set(words.acceptable_nouns())), "There are duplicated nouns"
     for word in words.acceptable_nouns():
         assert len(word) > 3, word
         assert word == word.strip()
@@ -17,12 +19,15 @@ def test_acceptable_nouns_set():
 
 def test_acceptable_adjectives_set():
     assert len(words.acceptable_adjectives()) > 1000
+    assert len(words.acceptable_adjectives()) == len(set(words.acceptable_adjectives())), "There are duplicated nouns"
     for word in words.acceptable_adjectives():
         assert len(word) > 3, word
         assert word == word.strip()
 
 
 def test_generate_corpus_id():
-    assert len(words.generate_corpus_id()) > 7
-    # 1 in 5073324 (3714 x 1366) times this will fail
-    assert words.generate_corpus_id() !=  words.generate_corpus_id()
+    with pytest.warns(None) as record:
+        assert len(words.generate_corpus_id()) > 7
+        # 1 in 5073324 (3714 x 1366) times this will fail
+        assert words.generate_corpus_id() != words.generate_corpus_id()
+    assert len(record) == 0

--- a/nbformat/corpus/words.py
+++ b/nbformat/corpus/words.py
@@ -7,13 +7,13 @@ from functools import lru_cache
 @lru_cache(1)
 def acceptable_nouns():
     with open(os.path.join(os.path.dirname(__file__), 'nouns.txt'), 'r') as nouns_file:
-        return set(word.rstrip() for word in nouns_file.readlines())
+        return list(word.rstrip() for word in nouns_file.readlines())
 
 
 @lru_cache(1)
 def acceptable_adjectives():
     with open(os.path.join(os.path.dirname(__file__), 'adjectives.txt'), 'r') as adjectives_file:
-        return set(word.rstrip() for word in adjectives_file.readlines())
+        return list(word.rstrip() for word in adjectives_file.readlines())
 
 
 def generate_corpus_id():


### PR DESCRIPTION
to avoid deprecation warnings under Python 3.9.1

May fix #212