### PR TITLE
Return the notebook when no conversion is needed

### DIFF
--- a/nbformat/v4/convert.py
+++ b/nbformat/v4/convert.py
@@ -70,7 +70,7 @@ def upgrade(nb, from_version=None, from_minor=None):
         return nb
     elif from_version == 4:
         if from_minor == nbformat_minor:
-            return
+            return nb
 
         # other versions migration code e.g.
         # if from_minor < 3:


### PR DESCRIPTION
The bare return statement returns None by default. If nothing is to be upgraded, the original notebook should be returned.