### PR TITLE
Don't list pytest-cov as a test dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         pip install --upgrade pip setuptools
         pip install .[test]
-        pip install codecov
+        pip install codecov pytest-cov
     - name: Install nbformat
       run: |
         pip install .

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ install_requires = setuptools_args['install_requires'] = [
 
 extras_require = setuptools_args['extras_require'] = {
     'fast': ['fastjsonschema'],
-    'test': ['check-manifest', 'fastjsonschema', 'testpath', 'pytest', 'pytest-cov'],
+    'test': ['check-manifest', 'fastjsonschema', 'testpath', 'pytest'],
 }
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
It is not actually required to run the tests.

It is only used when explicitly enabled via the --cov option,
e.g. on GitHub actions, where we install the package manually now.

In Fedora, we don't run the tests with --cov, so we don't need the dependency.