### PR TITLE
Ensure nbformat minor version is present when upgrading

### DIFF
--- a/nbformat/tests/no_min_version.ipynb
+++ b/nbformat/tests/no_min_version.ipynb
@@ -1,0 +1,20 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "plaintext"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4
+}

--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -232,3 +232,12 @@ def test_invalid_cell_id():
     with pytest.raises(ValidationError):
         validate(nb)
     assert not isvalid(nb)
+
+def test_notebook_invalid_without_min_version():
+    with TestsBase.fopen(u'no_min_version.ipynb', u'r') as f:
+        nb = read(f)
+    #with pytest.raises(ValidationError):
+    validate(nb)
+
+def test_notebook_invalid_without_main_version():
+    pass

--- a/nbformat/tests/test_validator.py
+++ b/nbformat/tests/test_validator.py
@@ -235,9 +235,9 @@ def test_invalid_cell_id():
 
 def test_notebook_invalid_without_min_version():
     with TestsBase.fopen(u'no_min_version.ipynb', u'r') as f:
-        nb = read(f)
-    #with pytest.raises(ValidationError):
-    validate(nb)
+        nb = read(f, as_version=4)
+    with pytest.raises(ValidationError):
+        validate(nb)
 
 def test_notebook_invalid_without_main_version():
     pass

--- a/nbformat/v4/convert.py
+++ b/nbformat/v4/convert.py
@@ -5,6 +5,7 @@
 
 import json
 import re
+from .. import validator
 
 from .nbbase import (
     random_cell_id,
@@ -38,6 +39,8 @@ def upgrade(nb, from_version=None, from_minor=None):
     if not from_version:
         from_version = nb['nbformat']
     if not from_minor:
+        if not 'nbformat_minor' in nb:
+            raise validator.ValidationError('The notebook does not include the nbformat minor which is needed')
         from_minor = nb['nbformat_minor']
 
     if from_version == 3:

--- a/nbformat/v4/tests/test_convert.py
+++ b/nbformat/v4/tests/test_convert.py
@@ -7,6 +7,8 @@ from unittest import mock
 from nbformat import validate
 from .. import convert
 from ..nbjson import reads
+import pytest
+from nbformat import ValidationError
 
 from . import nbexamples
 from nbformat.v3.tests import nbexamples as v3examples
@@ -89,3 +91,11 @@ def test_upgrade_v4_to_4_dot_5():
     assert nb_up['nbformat_minor'] == 5
     validate(nb_up)
     assert nb_up.cells[0]['id'] is not None
+
+def test_upgrade_without_nbminor_version():
+    here = os.path.dirname(__file__)
+    with io.open(os.path.join(here, os.pardir, os.pardir, 'tests', "no_min_version.ipynb"), encoding='utf-8') as f:
+        nb = reads(f.read())
+    
+    with pytest.raises(ValidationError):
+        convert.upgrade(nb) 


### PR DESCRIPTION
Motivation:
  - We have seen a number of notebooks which do not contain the nbformat
    minor version, this throws a key error when trying to update. This
    pr adds a check to ensure it is present and throws a validation error
    if not.