### PR TITLE
Add project URLs to setup.py

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,14 +5,14 @@ message = Bump version: {current_version} → {new_version}
 tag = False
 tag_name = {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = beta
-values = 
+values =
 	beta
 	prod
 
@@ -20,7 +20,7 @@ values =
 
 [bumpversion:file:nbformat/_version.py]
 parse = (?P<major>\d+),\s*(?P<minor>\d+),\s*(?P<patch>\d+)(,\s*['"](?P<release>[a-z]+)(?P<build>\d+)['"])?
-serialize = 
+serialize =
 	{major}, {minor}, {patch}, "{release}{build}"
 	{major}, {minor}, {patch}
 
@@ -32,6 +32,6 @@ replace = version = "{new_version}"
 
 [bumpversion:file:package.json]
 parse = (?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(-(?P<release>[a-z]+)\.(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}.{build}
 	{major}.{minor}.{patch}

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup_args = dict(
     keywords=["Interactive", "Interpreter", "Shell", "Web"],
     project_urls={
         "Documentation": "http://nbformat.readthedocs.io/",
+        "Funding": "https://numfocus.org/donate-to-jupyter",
         "Source": "https://github.com/jupyter/nbformat",
         "Tracker": "https://github.com/jupyter/nbformat/issues",
     },

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,11 @@ setup_args = dict(
     python_requires=">=3.7",
     platforms="Linux, Mac OS X, Windows",
     keywords=["Interactive", "Interpreter", "Shell", "Web"],
+    project_urls={
+        "Documentation": "http://nbformat.readthedocs.io/",
+        "Source": "https://github.com/jupyter/nbformat",
+        "Tracker": "https://github.com/jupyter/nbformat/issues",
+    },
     classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",


### PR DESCRIPTION
Adding project URLs (especially source code URL) makes it easier for dependency management tools (like Renovate).