### PR TITLE
Fix import nbformat.current

### DIFF
--- a/nbformat/current.py
+++ b/nbformat/current.py
@@ -11,7 +11,7 @@
 import re
 import warnings
 
-warnings.warning(
+warnings.warn(
     """nbformat.current is deprecated.
 
 - use nbformat for read/write/validate public API


### PR DESCRIPTION
`warnings` don't have `warning` method, but have `warn` https://docs.python.org/3/library/warnings.html#warnings.warn