### PR TITLE
Fix url in setup_args to https

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ text = "This package contains the base implementation of the Jupyter Notebook fo
 content-type = "text/plain"
 
 [project.urls]
-Homepage = "http://jupyter.org"
+Homepage = "https://jupyter.org"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
I noticed `url` had `http://`. [nbclient](https://github.com/jupyter/nbclient/blob/main/setup.py#L37) has it correct plus http on jupyter.org is redirected to https.