### PR TITLE
Start separating normalisation from validation logic

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,18 @@ Changes in nbformat
 In Development
 ==============
 
+The  biggest change in nbformat 5.5.0 is the deprecation of arguments to
+``validate()`` that try to fix notebooks errors during validation.
+
+``validate()`` is a function that is core to the security model of Jupyter,
+and is assumed in a number of places to not mutate it's argument, or try to fix
+notebooks passed to it.
+
+Auto fixing of notebook in validate can also hide subtle bugs, and will
+therefore be updated in a near future to not take any of the argument related to
+auto-fixing, and fail instead of silently modifying its parameters on invalid
+notebooks.
+
 5.4.0
 =====
 * Add project URLs to ``setup.py``

--- a/nbformat/current.py
+++ b/nbformat/current.py
@@ -42,7 +42,7 @@ from nbformat.v3 import (
 from . import versions
 from .converter import convert
 from .reader import reads as reader_reads
-from .validator import ValidationError, validate
+from .validator import ValidationError, isvalid, validate
 
 __all__ = [
     "NotebookNode",
@@ -61,6 +61,7 @@ __all__ = [
     "to_notebook_json",
     "convert",
     "validate",
+    "isvalid",
     "NBFormatError",
     "parse_py",
     "reads_json",
@@ -165,11 +166,7 @@ def reads(s, format="DEPRECATED", version=current_nbformat, **kwargs):
         _warn_format()
     nb = reader_reads(s, **kwargs)
     nb = convert(nb, version)
-    try:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            validate(nb, repair_duplicate_cell_ids=False)
-    except ValidationError as e:
+    if not isvalid(nb):
         get_logger().error("Notebook JSON is invalid: %s", e)
     return nb
 
@@ -195,11 +192,7 @@ def writes(nb, format="DEPRECATED", version=current_nbformat, **kwargs):
     if format not in {"DEPRECATED", "json"}:
         _warn_format()
     nb = convert(nb, version)
-    try:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            validate(nb, repair_duplicate_cell_ids=False)
-    except ValidationError as e:
+    if not isvalid(nb):
         get_logger().error("Notebook JSON is invalid: %s", e)
     return versions[version].writes_json(nb, **kwargs)
 

--- a/nbformat/current.py
+++ b/nbformat/current.py
@@ -166,7 +166,9 @@ def reads(s, format="DEPRECATED", version=current_nbformat, **kwargs):
     nb = reader_reads(s, **kwargs)
     nb = convert(nb, version)
     try:
-        validate(nb)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            validate(nb, repair_duplicate_cell_ids=False)
     except ValidationError as e:
         get_logger().error("Notebook JSON is invalid: %s", e)
     return nb
@@ -194,7 +196,9 @@ def writes(nb, format="DEPRECATED", version=current_nbformat, **kwargs):
         _warn_format()
     nb = convert(nb, version)
     try:
-        validate(nb)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            validate(nb, repair_duplicate_cell_ids=False)
     except ValidationError as e:
         get_logger().error("Notebook JSON is invalid: %s", e)
     return versions[version].writes_json(nb, **kwargs)

--- a/nbformat/current.py
+++ b/nbformat/current.py
@@ -84,7 +84,7 @@ class NBFormatError(ValueError):
 
 def _warn_format():
     warnings.warn(
-        """Non-JSON file support in nbformat is deprecated.
+        """Non-JSON file support in nbformat is deprecated since nbformat 1.0.
     Use nbconvert to create files of other formats."""
     )
 
@@ -107,13 +107,21 @@ def parse_py(s, **kwargs):
 
 def reads_json(nbjson, **kwargs):
     """DEPRECATED, use reads"""
-    warnings.warn("reads_json is deprecated, use reads")
+    warnings.warn(
+        "reads_json is deprecated since nbformat 3.0, use reads",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return reads(nbjson)
 
 
 def writes_json(nb, **kwargs):
     """DEPRECATED, use writes"""
-    warnings.warn("writes_json is deprecated, use writes")
+    warnings.warn(
+        "writes_json is deprecated since nbformat 3.0, use writes",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return writes(nb, **kwargs)
 
 

--- a/nbformat/json_compat.py
+++ b/nbformat/json_compat.py
@@ -88,6 +88,8 @@ def _validator_for_name(validator_name):
     for (name, module, validator_cls) in _VALIDATOR_MAP:
         if module and validator_name == name:
             return validator_cls
+    # we always return something.
+    raise ValueError(f"Missing validator for {repr(validator_name)}")
 
 
 def get_current_validator():

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -275,7 +275,7 @@ def normalize(nbdict, version, version_minor):
 
     """
     nbdict = deepcopy(nbdict)
-    return _normalize(nbdict)
+    return _normalize(nbdict, version, version_minor, True)
 
 
 def _normalize(nbdict, version, version_minor, repair_duplicate_cell_ids):

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -114,12 +114,17 @@ def isvalid(nbjson, ref=None, version=None, version_minor=None):
     To see the individual errors that were encountered, please use the
     `validate` function instead.
     """
+    orig = deepcopy(nbjson)
     try:
-        validate(nbjson, ref, version, version_minor)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            validate(nbjson, ref, version, version_minor, repair_duplicate_cell_ids=False)
     except ValidationError:
         return False
     else:
         return True
+    finally:
+        assert nbjson == orig
 
 
 def _format_as_index(indices):

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -296,7 +296,14 @@ def normalize(
         version = nbdict_version
     if version_minor is None:
         version_minor = nbdict_version_minor
-    return _normalize(nbdict, version, version_minor, True, relax_add_props=relax_add_props)
+    return _normalize(
+        nbdict,
+        version,
+        version_minor,
+        True,
+        relax_add_props=relax_add_props,
+        strip_invalid_metadata=False,
+    )
 
 
 def _normalize(
@@ -305,7 +312,7 @@ def _normalize(
     version_minor: int,
     repair_duplicate_cell_ids: bool,
     relax_add_props: bool,
-    strip_invalid_metadata: bool = False,
+    strip_invalid_metadata: bool,
 ) -> Tuple[Any, int]:
     """
     Private normalisation routine.

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -407,10 +407,31 @@ def validate(
 
     Parameters
     ----------
+    nbdict : dict
+        notebook document
     ref : optional, str
         reference to the subset of the schema we want to validate against.
         for example ``"markdown_cell"``, `"code_cell"` ....
-    Raises ValidationError if not valid.
+    version : int
+    version_minor : int
+    relax_add_props : bool
+        Deprecated since 5.5.0 – will be removed in the future.
+        Wether to allow extra property in the Json schema validating the
+        notebook.
+    nbjson :
+    repair_duplicate_cell_ids : boolny
+        Deprecated since 5.5.0 – will be removed in the future.
+    strip_invalid_metadata : bool
+        Deprecated since 5.5.0 – will be removed in the future.
+
+    Returns
+    -------
+    None
+
+
+    Raises
+    ------
+    ValidationError if not valid.
     """
     assert isinstance(ref, str) or ref is None
 

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -406,7 +406,7 @@ def validate(
         raise error
 
 
-def _try_fix_error(nbdict, version, version_minor, relax_add_props):
+def _try_fix_error(nbdict, version: int, version_minor: int, relax_add_props: bool) -> int:
     """
     This function try to extract errors from the validator
     and fix them if necessary.
@@ -417,6 +417,7 @@ def _try_fix_error(nbdict, version, version_minor, relax_add_props):
         raise ValidationError(f"No schema for validating v{version}.{version_minor} notebooks")
     errors = [e for e in validator.iter_errors(nbdict)]
 
+    changes = 0
     if len(errors) > 0:
         if validator.name == "fastjsonschema":
             validator = get_validator(
@@ -428,7 +429,6 @@ def _try_fix_error(nbdict, version, version_minor, relax_add_props):
             errors = [e for e in validator.iter_errors(nbdict)]
 
         error_tree = validator.error_tree(errors)
-        changes = 0
         if "metadata" in error_tree:
             for key in error_tree["metadata"]:
                 nbdict["metadata"].pop(key, None)
@@ -460,7 +460,7 @@ def _try_fix_error(nbdict, version, version_minor, relax_add_props):
                                 nbdict["cells"][cell_idx]["metadata"].pop(rel_path[1], None)
                                 changes += 1
 
-            return 0
+    return changes
 
 
 def iter_validate(

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -118,6 +118,7 @@ def isvalid(nbjson, ref=None, version=None, version_minor=None):
     try:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", category=MissingIDFieldWarning)
             validate(nbjson, ref, version, version_minor, repair_duplicate_cell_ids=False)
     except ValidationError:
         return False

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -317,7 +317,6 @@ def _normalize(
     """
     Private normalisation routine.
 
-
     This function attempts to normalize the `nbdict` passed to it.
 
     As `_normalize()` is currently used both in `validate()` (for
@@ -418,7 +417,7 @@ def validate(
         Deprecated since 5.5.0 – will be removed in the future.
         Wether to allow extra property in the Json schema validating the
         notebook.
-    nbjson :
+    nbjson
     repair_duplicate_cell_ids : boolny
         Deprecated since 5.5.0 – will be removed in the future.
     strip_invalid_metadata : bool
@@ -427,7 +426,6 @@ def validate(
     Returns
     -------
     None
-
 
     Raises
     ------
@@ -500,7 +498,6 @@ def _strip_invalida_metadata(
     nbdict: Any, version: int, version_minor: int, relax_add_props: bool
 ) -> int:
     """
-
     This function tries to extract metadata errors from the validator and fix
     them if necessary. This mostly mean stripping unknown keys from metadata
     fields, or removing metadata fields altogether.
@@ -515,11 +512,10 @@ def _strip_invalida_metadata(
         Wether to allow extra property in the Json schema validating the
         notebook.
 
-    Return
-    ------
-    int :
+    Returns
+    -------
+    int
         number of modifications
-
 
     """
     validator = get_validator(version, version_minor, relax_add_props=relax_add_props)
@@ -587,12 +583,10 @@ def iter_validate(
 
     Returns a generator of all ValidationErrors if not valid.
 
-
     Notes
     -----
     To fix: For security reasons, this function should *never* mutate its `nbdict` argument, and
     should *never* try to validate a mutated or modified version of its notebook.
-
 
     """
     # backwards compatibility for nbjson argument

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -7,6 +7,7 @@ import os
 import pprint
 import warnings
 from copy import deepcopy
+from textwrap import dedent
 from typing import Any, Optional, Tuple
 
 from ._imports import import_item
@@ -259,15 +260,12 @@ def normalize(
     """
     Normalise a notebook prior to validation.
 
-    .. note::
-
-        Experimental
-
     This tries to implement a couple of normalisation steps to standardise
     notebooks and make validation easier.
 
     You should in general not rely on this function and make sure the notebooks
-    that reach nbformat are already in a normal form.
+    that reach nbformat are already in a normal form. If not you likely have a bug,
+    and may have security issues.
 
     Parameters
     ----------
@@ -362,12 +360,15 @@ def _normalize(
 
 def _dep_warn(field):
     warnings.warn(
-        f"""`{field}` kwargs of validate has been deprecated for security reason, and will be removed soon.
+        dedent(
+            f"""`{field}` kwargs of validate has been deprecated for security
+        reasons, and will be removed soon.
 
         Please explicitly use the `new_notebook,n_changes = nbformat.validator.normalize(old_notebook, ...)` if you wish to
         normalise your notebook. `normalize` is available since nbformat 5.5.0
 
-        """,
+        """
+        ),
         DeprecationWarning,
         stacklevel=3,
     )
@@ -433,10 +434,9 @@ def validate(
         if version is None:
             version, version_minor = 1, 0
 
-    assert isinstance(version, int)
-    assert isinstance(version_minor, int)
-
     if ref is None:
+        assert isinstance(version, int)
+        assert isinstance(version_minor, int)
         _normalize(
             nbdict,
             version,

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -288,7 +288,14 @@ def normalize(nbdict, version=None, version_minor=None, *, relax_add_props: bool
     return _normalize(nbdict, version, version_minor, True, relax_add_props=relax_add_props)
 
 
-def _normalize(nbdict, version, version_minor, repair_duplicate_cell_ids, relax_add_props):
+def _normalize(
+    nbdict,
+    version,
+    version_minor,
+    repair_duplicate_cell_ids,
+    relax_add_props,
+    strip_invalid_metadata=False,
+):
     """
     Private normalisation routine.
 
@@ -338,8 +345,8 @@ def _normalize(nbdict, version, version_minor, repair_duplicate_cell_ids, relax_
                 else:
                     raise ValidationError(f"Non-unique cell id '{cell_id}' detected.")
             seen_ids.add(cell_id)
-
-    changes += _try_fix_error(nbdict, version, version_minor, relax_add_props=relax_add_props)
+    if strip_invalid_metadata:
+        changes += _try_fix_error(nbdict, version, version_minor, relax_add_props=relax_add_props)
     return changes, nbdict
 
 
@@ -392,6 +399,7 @@ def validate(
             version_minor,
             repair_duplicate_cell_ids,
             relax_add_props=relax_add_props,
+            strip_invalid_metadata=strip_invalid_metadata,
         )
 
     for error in iter_validate(

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -430,6 +430,16 @@ def validate(
     Raises
     ------
     ValidationError if not valid.
+
+
+    Notes
+    -----
+
+    Prior to Nbformat 5.5.0 the `validate` and `isvalid` method would silently
+    try to fix invalid notebook and mutate arguments. This behavior is deprecated
+    and will be removed in a near future.
+
+    Please explicitly call `normalize` if you need to normalize notebooks.
     """
     assert isinstance(ref, str) or ref is None
 

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -7,6 +7,7 @@ import os
 import pprint
 import warnings
 from copy import deepcopy
+from typing import Any, Optional
 
 from ._imports import import_item
 from .corpus.words import generate_corpus_id
@@ -247,7 +248,13 @@ def better_validation_error(error, version, version_minor):
     return NotebookValidationError(error, ref)
 
 
-def normalize(nbdict, version=None, version_minor=None, *, relax_add_props: bool = False):
+def normalize(
+    nbdict: Any,
+    version: Optional[int] = None,
+    version_minor: Optional[int] = None,
+    *,
+    relax_add_props: bool = False,
+) -> Any:
     """
     Normalise a notebook prior to validation.
 
@@ -414,7 +421,7 @@ def validate(
         raise error
 
 
-def _try_fix_error(nbdict, version: int, version_minor: int, relax_add_props: bool) -> int:
+def _try_fix_error(nbdict: Any, version: int, version_minor: int, relax_add_props: bool) -> int:
     """
     This function try to extract errors from the validator
     and fix them if necessary.

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -5,11 +5,8 @@
 import json
 import os
 import pprint
-import sys
 import warnings
 from copy import deepcopy
-
-from traitlets.log import get_logger
 
 from ._imports import import_item
 from .corpus.words import generate_corpus_id

--- a/nbformat/warnings.py
+++ b/nbformat/warnings.py
@@ -1,0 +1,32 @@
+"""
+Warnings that can be emitted by nbformat.
+"""
+
+
+class MissingIDFieldWarning(FutureWarning):
+    """
+
+    This warning is emitted in the validation step of nbformat as we used to
+    mutate the structure which is cause signature issues.
+
+    This will be turned into an error at later point.
+
+    We subclass FutureWarning as we will change the behavior in the future.
+
+    """
+
+    pass
+
+
+class DuplicateCellId(FutureWarning):
+    """
+
+    This warning is emitted in the validation step of nbformat as we used to
+    mutate the structure which is cause signature issues.
+
+    This will be turned into an error at later point.
+
+    We subclass FutureWarning as we will change the behavior in the future.
+    """
+
+    pass

--- a/tests/test4.5.ipynb
+++ b/tests/test4.5.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2fcdfa53",
+   "metadata": {},
+   "source": [
+    "# nbconvert latex test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bc81532",
+   "metadata": {},
+   "source": [
+    "**Lorem ipsum** dolor sit amet, consectetur adipiscing elit. Nunc luctus bibendum felis dictum sodales. Ut suscipit, orci ut interdum imperdiet, purus ligula mollis *justo*, non malesuada nisl augue eget lorem. Donec bibendum, erat sit amet porttitor aliquam, urna lorem ornare libero, in vehicula diam diam ut ante. Nam non urna rhoncus, accumsan elit sit amet, mollis tellus. Vestibulum nec tellus metus. Vestibulum tempor, ligula et vehicula rhoncus, sapien turpis faucibus lorem, id dapibus turpis mauris ac orci. Sed volutpat vestibulum venenatis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb687f78",
+   "metadata": {},
+   "source": [
+    "## Printed Using Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "38f37a24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"hello\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1f70963",
+   "metadata": {},
+   "source": [
+    "## Pyout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8206b3b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script>\n",
+       "console.log(\"hello\");\n",
+       "</script>\n",
+       "<b>HTML</b>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML at 0x1112757d0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import HTML\n",
+    "HTML(\"\"\"\n",
+    "<script>\n",
+    "console.log(\"hello\");\n",
+    "</script>\n",
+    "<b>HTML</b>\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "88d8965b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "console.log(\"hi\");"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript at 0x1112b4b50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%javascript\n",
+    "console.log(\"hi\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34334c4f",
+   "metadata": {},
+   "source": [
+    "### Image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8b414a68",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAggAAABDCAYAAAD5/P3lAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAH3AAAB9wBYvxo6AAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAACAASURB\nVHic7Z15uBxF1bjfugkJhCWBsCSAJGACNg4QCI3RT1lEAVE+UEBNOmwCDcjHT1wQgU+WD3dFxA1o\nCAikAZFFVlnCjizpsCUjHQjBIAkQlpCFJGS79fvjdGf69vTsc2fuza33eeaZmeqq6jM9vZw6dc4p\nBUwC+tE+fqW1fqmRDpRSHjCggS40sBxYDCxKvL8KzNBaL21EPoPB0DPIWVY/4NlE0ffzYfhgu+Qx\nGHoy/YFjaK+CcB3QkIIAHAWs3wRZsuhUSs0CXgQeBm7UWi/spn0Z+jA5yxpEfYruqnwYllRic5a1\nMaWv8U5gaT4M19Sx396IAnZLfB/SLkEMhp5O/3YL0AvoAHaKXl8HLlZK3QZcpbWe0lbJDOsaHuDU\n0e4u4JAy2wPk/C1JzrKWArOQ0fUtwH35MOysQxaDwbCO0NFuAXoh6wPjgQeUUvcqpUa0WyCDoQls\nCIwBjgfuAV7KWdY+7RWpmJxlXZezrEdylvXxdstiMKzrGAtCYxwI/EspdZbW+g/tFsbQ67kQuBHY\nFNgseh9FV6vCbUAeWBC9PgBeq2EfS6J2MQOBrRDTe5KdgAdzlvW1fBjeUUP/3UbOsoYBE6OvG7VT\nFoOhL9Af+BUwFLkZpV+DaY6V4UPkRpb1+ncT+m8nGwK/V0oN01qf025hDL2XfBi+DLycLMtZVo6u\nCsKfGnSq8/NheEpqHwOBEcDBwJnAsGhTP2ByzrJG5cPwnQb22Sy+0G4BDIa+RH+t9dmlNiqlFKIk\nJJWGi+jq5JPmq8BbJJQArfXqpkncczlbKbVQa/3rdgtiMNRCPgxXAK8Ar+Qs63LgXmDvaPPGwPeA\nH7VJvCRfbLcABkNfouwUg9ZaAwuj178BlFLvVejzgR4WFviM1npcuQpKqf6IyXIjxLS7GzAWuUnu\nXsO+fqWUellr3ZBJdq/jr9+BDn1uve07O9Rz0y6f8PtGZGgWe53oT6SBkZ/q1/nHZy47aloTRTKU\nIR+Gy3OWNR6Zxtg0Kv4KRkEwGPocxgcBiCwcsSI0F5iOhF+ilPok8C3gVGS+thK/VErdrbWuO2ys\ns/+aLZTuOKbe9krrIUCPUBB0B+PQ1P1bdKe6EzAKQgvJh+GbOct6gkJkxM45y+qXDIWMHBhjBWJe\nPgyDWvaRs6zPIVObAG/nw/DpEvUGAp8E9gGGJzbtl7Os7cvs4skqp0V0Yl8jgcOBjyMDhbmIZeWl\nfBg+UUVfReQsayhwELAnsAXi6/E28BxwTz4MP6iyn92RaSCA+/NhuCwqXx9R4MYhU0MfRTK/AjyW\nD8MFGd0ZDFVhFIQKaK3/BXxfKXUlklTq0xWafAI4Driyu2UzGLqRlygoCArYHJif2H4gcFb0+Z2c\nZW2bD8NV1XScs6yNgH8g/jsAPwCeTmzfFPgjYsnbiez71MUVdnMQcF8V4nyUs6whwB8QX4+0s2Ys\n0yPAt/NhGFbRZ/wbzgO+DaxXotqqnGX9GbigCkXhf5CBCsDngYdzljURGQhsWqLN+znL+iFwdT4M\ndYk6BkNJTJhjlWitQ2Bf4P4qqv848t8wGHor6Yd9+ruHJFkC2BI4rIa+D6egHKwmstYlGAxMQCwH\nrRjEPI5ER5S7ZvcFXsxZ1phKneUsawSi8HyH0soB0bbvAM9Ebaplt5xlnYkct1LKAYiFZhJwSQ19\nGwxrMRaEGtBar1RKfRX4JxIzXortou3PN1mE+YgJsSwaeoLHOQCqUy3QSr9eqZ6G/gq2aYVMhqrY\nOfF5FeJwvJZ8GM7JWdY/gC9HRS7wtyr7Pjrx+e6MqYC3KLbU7Qhck/h+FJIKvRRVjfSREXicU8EH\npgAvIIqLBZwGfC7avl5Uf29KkLOsTZCMq8npj9sQx89no37HIlaAODplNPBIzrJ2z4dhNVlaT0HC\nXwFmIkrAC4if2PaIz8/3KCgn385Z1pX5MJxeRd8Gw1qMglAjWutlSqnTgUcqVP0SzVYQtP5mcMXE\nSvvtUUy9YsK5QEWHy7EnTB6lOtSsFohkqEDOsgYAdqJoagkT9Z8pKAj75yzr4/kwnF2h748ho/GY\nq9J1oqiKLj4JOctKK8Yz8mH4Yrl9VcnHkXVYTsyHoZ8WJWdZNyPThbF5/3M5yzowH4alpi9+T0E5\nWA18Nx+Gf0zVeRG4KmdZ90R9bwCMRKwyX69C5h2j91uA4/JhuCSxbTYwJWdZtwNPIFbifsAFSISZ\nwVA1ZoqhDrTWjyIjjXIc3ApZDIZu4ELgY4nvt5Wody8wJ/qsgBOr6HsihfvOfCRrY7v5dYZyAECk\nGP0ISEZmZYZ55yxrB8SyEXNxhnKQ7Pt64H8TRUfmLGuXKmWeC4xPKQfJvp9CLCJlZTYYymEUhPq5\ntcL2XVsihcHQJHKWtU3Osi5GnAZj5iKWgiKitRouTxQdl7OscnPu0HV64dp8GLY7R8pyxEGxJPkw\nfBcZ9ceUSvN8IoV76upK/UZcgawcG3NKqYopfleFU+gDic/b5SzLWIwNNWFOmPqp5CG9sVJqPa11\nVZ7dBkOL2D1nWcmcBkOR8MFtgM/QdTXJZcCR+TBcXqa/SYj5egAFZ8VMX4ScZe2FRPnEXF2z9M3n\n3nwYVsrtAmK6/0z0uVR4ZXLtivvzYfhGpU7zYbgkZ1k3ACdHRQdWIQsUO3ZmkUzB3Q/xjaolLbeh\nj2MUhDrRWr+mlFpJ+eV5hyIxz4YWs98Fj/Rf8uZbozo0/ZYt7D8rf9ORK9stUw/hU9GrEnMAp1R+\ngph8GL4bzdNPiIpOorSzYtJ68FS1IYPdTLWp3hcnPm+Q3pizrA7E+TCmFn+aZN0dcpY1LB+G5e4b\ny6rM8bA49X39GmQyGMwUQ4NUGnkMrbDd0A3sdeLk4z6cN+89pTtDTWd+gyErF+7pTv5eu+XqJbyK\nTDHsmg/DJ6tsc2ni8+dzljUqXSGaevhmoqjIObFNVBzlV8kQug4W5tbQNl13WGatAv+poW+DoW6M\nBaExPgC2LrO9nHWhpSilDqI4NPMhrfXUJvS9M/DfqeJXtdY3N9p3rex50uQ9lFKT6BrTvoFCXbTX\nyZNfmnrZxHtbLVMP4xng74nvK5DzeD7wfIWRayb5MHwiZ1kzgF0oOCuemar2ZQoK8zLgr7Xup5t4\ns0n9DEl9b0RBSPeV5q0a+jYY6sYoCI1RacnZ91siRXUMAH6eKnsYicdulDOAY1NlpzWh35pRqG9R\nIuGN7uw4AfG878s8nw/DX3RDv5dScGY8NmdZP86HYXJaJzm9cHMp7/s2UHdK9BTpKaxBNbRN163k\nt9Rux05DH8FMMTTGZhW2v9sSKarjbopNk/sqpUY30qlSahCSGS/JCuD6RvqtF6UpMm/HaHTJbYaG\nmQzED/0umRVzlrUZhXwJ0HOmF5pJOlXyxzJrZbNt6rtZP8HQIzAKQp0opTZAlsItxTKtdTnv75YS\nLR7lpYqrjV0vx2EUH4fbtdZtucnpMqOrDjPy6jYii8DkRFHSYnAEhem22cBjrZKrVeTDcCldTf/p\nh345ksrEGprnF2EwNIRREOrnMxW2z2uJFLVxJcXmy2OVUo34ShydUda+EaIq7T2u0SZTY/eSdFY8\nMGdZm0efk86J6/LCQUnFp5pIkZjkcvQz8mH4YZPkMRgawigI9VNp7v7BlkhRA1rr+RQneNqC2hba\nWYtSajiS9z3JXLomaGktq/VllLIUdKqSWe0MjZMPwxlIel8Q/6Zv5CxrGIX8AJ10XU+hFtIRQ+UW\nKWoXyYyTu+Qsa79KDXKWNRpJyx5zZ9OlMhjqxCgIdaCU6g98o0K1npBCNotLM8rcOvuagCRgSXKN\n1rozq3IrCCZNfFkrfRjotWsCaJinUBODK51/tkuuPkTy/DoYOIDCfeb+fBjW4t2/lqhdcmRdbUri\nVnILXS2HZ1WRvfAcCk61K4A/dYdgBkM9GAWhPr5F6XSrIBf6Qy2SpSaidSReShV/XilV7veUIj29\noOkB2fGmXT7x7sCbOGpFf7VZx4A1m0/znG2nehMyc+0bms7NFJxzxwH7J7Y1OvWUPG9/mLOsLRvs\nr6lEaaOT0TtfBB5ITLWsJWdZg3KWdRNwTKL4wnwYzu9mMQ2GqjFhjjWilBqBpJYtx51a66UV6rST\nS+maJz52VvxRdvVilFK7UbzexGNa67Kr+bWS6X+ekPYs79HkLGt34JOI+Xyz6D2d1vfMnGUdini6\nL0C851/Oh2HD+SyaQT4MV+YsaxJyLm1Gwf9gAXBHg93/JNHHtsArOcuajCztPBDYCkkytBXg5sOw\n5QmF8mF4W86yLgK+HxXtC8zKWVaALMm8CslHsicS7RFzL8VhyAZDWzEKQg0opbYE7qd8prPVdF2h\nrSdyLfALYMNE2XFKqR/XsHbEURll62L4Wiv5PuBUqPPF6JXkLuCQbpGoPi4HfohYKGMHWD9axrlu\n8mF4Z7RuwfioaDBwaonqRemQW0U+DH+Qs6xFwHnIFNwQsv+3mMnA8dHiVwZDj8FMMVSJUuow4DkK\na7GX4gqt9cstEKlutNaL6boULMho5tBq2iul+lH8IFuCmJcNfZx8GM6hOCFVU5THfBhOQHxfylkH\n3gY+asb+6iUfhhcCewC3l5BlFbJk/P75MDwqlVTKYOgRKK1rizhSSk2h67ximo1abV5XSi2n9EIk\nz2itx5XYVqnfQcjI7DiqW2XtfeCTUbRA3ex50nWfUrqjeJEcrfcLrpj4SCN9xyilxgDPp4of0Fof\nUEXbg4B/pIqv1FrXnVNh7AmTR3V0qIwwRH1E4E28pd5+De0hZ1m/Bb4bfX0+H4Z7dMM+hgGjkDwC\nS5FpjFk9bR4/Z1mDkGmF4VHR20g4Y3oxJYOhR9EXphg6lFLlVjFbH0mZvDGwCTAayCFe0ntTOZ1y\nzDLgkEaVg1ahtX5BKfUU8OlE8ReUUjtorSstCduzch8YehSR5/6ERFG3nBvRuhE9frXUfBguA6pd\n+Mpg6DH0BQXBBro7o+Ea4Bta66e6eT/N5lK6KggKOAE4u1QDpdTGFOdNmNkLf7uh+zgYcRQEMa+3\nJe22wWBoDOOD0DhLgYla67vaLUgd3ETxglLHRXkeSnEExQ5gbQ9tNPQokis5TsqHoVlbwGDohRgF\noTECYHet9Y3tFqQetNYrKDb/DqN46eYk6emF1UhUhMFAzrImUEhDvgr4VRvFMRgMDWAUhPpYAvwf\n8Bmte31+/8uQBEdJMjMrKqW2o5A2N+YfWusePw9s6F5yltWRs6zxwKRE8RXtyEVgMBiaQ1/wQWgm\neWTe/jqtdU9Zz74htNavKaXuAw5KFB+glBqptZ6Tqj6RQlrYGDO90AfJWdY5wNeQFQwHIAmetk5U\neZFCsiCDwdALMQpCed5AphEC4NF12BHvUroqCAoJ7TwvVS+d++BdJEmPoe+xKRLnn0UeODwfhm3N\nRWAwGBqjLygIbwN/LbNdI1MGH6ReL/eWkMUmcDeSeGa7RNlRSqnzdZQoQym1C7Bzqt11NWReNKxb\nzEMU6GHAesBiYCaSLOviaF0Cg8HQi+kLCsLrWuvT2y1ET0ZrvUYp5SG57mO2Bz4LPB59/2ZRQ5P7\noM+SD8OLgYvbLYfBYOg+jJOiIeZKxOs8STJiIb28daC1/lf3imQwGAyGdmEUBAMA0XTKraniI5VS\nA6O0zOnloI31wGAwGNZhjIJgSHJp6vtgJBNlehW65cANLZHIYDAYDG3BKAiGtWitHwVeShV/muLF\nuW7VWi9qjVQGg8FgaAd9wUnRUBuXAn9IfN8f+FyqTo/OfbDnSX8brDpXnqEUe2ropzQvdtDx66ev\nGN9XolIMPQDb9T8LrBd4zsPtlsXQe7Bd/0BgQeA5QbtlMQqCIc21wC+ADaPv6WWu5wAPtVKgWtjt\n6Os2XG/9jhdQjIzTQ2rFF9bQecy4E2/I9UQlwXb9LYDDK1R7K/Cc21shj6FxbNcfDjwGKNv1Rwae\n83q7ZWo2tusPBb6ELGW9BbAICX99Gngs8Jx0hlZDBWzXHwvcC6ywXX9o4DlL2ymPURAMXdBaL1ZK\n+ZRItwz8Jc6N0BMZMFB9GxiZsWnzTjrPAH7QWomqYgTF/h9pngC6RUGwXf+XwC2B50ztjv57M7br\nXwJMCjxneo1NP0SWgAfJq7LOYLv+esAFwOkUL9wWM912/d0Dz+lsnWQ9A9v1BwEXAT8PPKfWVOML\nkPVt3kNWQm0rxgfBkEWph5UG/tJCOWqnQ40ttUkrvWcrRamWwHOmAZsguSfGAi9Hmy5AUhgPAz7f\nHfu2XX8k8ENgx+7ovzdju/4uwP9D/peaCDxnCbANsF3gOYubLVu7sF1/AHAHcBaiHDwI/C+ywNsE\n4KfA68BdfVE5iNgbOBmxqtRE4Dn/BoYDnwg8Z02zBasVY0EwFKG1fkEp9RTioJjkIa11zzaVarYq\nvVFt2TpBaiN6oCwB5tiu/2FUPCvwnLTTaLM5oJv77800dGwCz1kXHXkvRNKydwI/Cjzn1+kKtuuf\ni2TX7Ks0et681yxBGsUoCIZSBBQrCL0h98EbdW7rddiuPwoYFJu/bdffFNgL2BZ4DZgWKR5ZbRWS\n2+KIqGiE7fpjUtXmlrtZRdaHscBAYDowM/CckimWbdffFfgw8JzXou/9kfUccojV5MXAcz4s0XYw\nsCsymu8PzAVmBJ7zVqn9pdoPRVKF7wSsAN4EgqzRve36HcAoZDEqgO0zjs3rged8kGo3gOJ05ADT\ns0bTkan+k9HXGaVGjNFxykVf81nH2Hb9Ich/MRJJeT291H9fL7brj6CwANfPspQDgOi3rijRx/rI\nb8kB7wPPBZ4zL6Ne/JvfCDzn/WhufhvgvsBzVkR1dgN2AR4JPGduom38P7wXeM7c6FzfCfgU4iMR\nlFLebNfPIefXzMBzikz8tusPQyx676bljmTeCfhyVLST7frp//TV9Dluu/6GwOhUvTWB58zIkjFq\nsykyNfmfwHMW2K7fLzoWeyDTFPnAc14t1T7qYwNgT+Rc/wi5ZyT/N20UBEMRSqn+wNdTxQspTqTU\n41BaP6yVOipzGzzSYnG6m6uBz0YPv7OQm3dytc35tuuflHZutF3/BuArwEaJ4p/QNdU2wGnAH9M7\njRSTG5CbS5LQdv2joymTLKYBzwHjbNc/DomW2TCxfbXt+sMCz3k/sa8RwM+Qh/X6qf5W2q4/CTit\nzMN1OPB7CopQktW2658YeM5fEvXvRKZzBiXqZaWUPha4JlW2NfB8Rt0hiANfmjWIuf5jiLPfvVm/\nAfmvbgNmB54zKrkheuD+Bjg11Wap7fpnBJ5TybelFk4E+iE+Fb+ptbHt+scg//nGqfJbgeMDz1mY\nKN4UOZYX2q7fSWHhuNdt198ZOBc4MypbbLv+5wPPeTb6PiJqe5ft+ichx3WXRN8rbdc/OfCcrGis\nR4ChiHKSlSn2f4BzkOvitMRvCKJ9DEzU9TPafwGZlkkyBvExSrKUrtdnmoOBycA5tus/iCyat3li\nu7Zd/0rk2ihS1mzXPwT4E3LulaLTKAiGLL6EaMlJbtBat91pphIjFw289t9DVh4N7Jva9EKnWnpJ\nG0RqBXcjCa08YCqy/PJE4L8A33b9HQPPeTNR/0bgvujzGchoywPSq5U+nd6R7fp7IDfRjYDrEE99\nDeyHrPb5lO364xI36zTb2q4/AUnt/SSyLHQHMvJZklQOIhYChyCLid2FWBoGIQrDfwGnAP8Gskzd\nVvSbBgPvIMdpJjLHuxdikXgg1ewa4Jbo84+BHRAFI/3gT9/QQZa+/iIy9zwccVQrSeA5nbbrX4s8\ncI6htIIQK7xdFJLIAvEEYjmYBlyP/E4LeXj92Xb94YHnnFtOjhrYJ3q/vtbpE9v1fwqcjYxUL0GO\n51bI//g1YIzt+mNTSgJIivfNEIXgBOThfx0ySv8Nct7vgzgfj0+1HQf8E5iPKM/vI+vLHA9cZbs+\nJZSEevgDBZ++3yIKzgVI1FeSrCnD6ci0zebAJxCfjmoZjxzXPPBL5By0gW8jCt3sqHwtkYL1N0RB\n/R2ymOG2yHE5CLFAHAu8ahQEQxbfyijrDdML3HTTkWvUBRfsb88bPb6TzjEK+oHKL184YHL+Jmdl\nu+XrJsYBhwaec0dcYLu+hzw0dkcu/AvjbUmLgu36DqIgPB54zuQq9nURMgI8LjnyBibZrj8z2s/l\ntuvvVcJJbWvkXDoi8JzbKu0s8JxFtut/IqXgAPzOdv0/IiPnb5KhICAjpMGIEjAhPV1iu35HWsbA\nc25ObD8ZURAeqibENBqpTYnark8FBSHiakRBOMx2/cHpB29kSv4KooSlLRYnIcrBHcBXk7/Fdv0b\ngReAM23Xvz7wnJlVyFIJK3qfXUsj2/U/jiiiq4B9ktEytuv/Fhlpfx2xEnw31XxHYLfAc6bbrv8k\ncny/Bnwz8Jy/2q6/DTLd9F8Zu94ceXAeEHhOvM7MNbbrT0UU4vNs15+c2FY3gedcm/hNP0EUhDvL\nKMrJtkuIFPboWNWiIOSAO4HDE7/Dj67FSxEn21+m2pyOWDpuCDxn7fG2Xf8e4F1EIVsceE5oohgM\nXVBKjURuSEke11qXMhv3OPR553VO9Sb407yJZwTexO8FnnNV/qYj11XlAOCfSeUA1s4D/y36mp7f\nrAvb9fdGLDMzU8pBzMXIg2wsMhLKQiFhgxWVg5gM5SDm+uh9VHqD7fr7IlaNFcAJWb4UPcHLPvCc\n2YgVZn3gyIwq30AsQg8lQ+aiefUfR1/PzlB08sD9Udusfmsi2t+Q6GutjspnIE6L16dDaSN/irMR\np8dTbddPOxK/nwgxTZr8747e30SsEkNL7PvXGQrAVYgvwggK/gK9mXMyfuON0fvWkY9Dkp2i97uT\nhYHnLKNgURsDxknRUMz5FJ8XP22DHIbqSc9pxsSOW8ObtJ89ovdXbNcvpQC8j4zcdiTbnAoy4q2b\n6Ia3CYV5/Y0zqsXOf4/WEYveaq5GQuOOQaZekhydqJNkW2BLZF2UzhL/R+xE2XAIa+A52nb9lUho\nY63hd7GD5d1ZGwPPmW27/iuIUrkLXc/n9xP13rZd/yNgVezoF8n1NjAyyyKETGGl97fGdv1/IlaL\n3h7e+06WM2PgOQtt11+GTMcNo6vVJ1aWsyK+4nvFQjAKgiGBUmoshfnOmGe11vdl1Tf0GOaUKI9v\nlqrE9lqJb6b/Hb3KsU2Zba/VslPb9bdDfA0ORLz0N62iWWxVqMkc3iZuRuawP2u7/g6JKI9RSCTR\nYoodhOP/YgNKK2Ix2zZJzjnINMN2NbaL/4uiaIUE/0EUhB3pqiCkMwl2IscjXZZFJ/B2iW1xRtWR\nZWTqDcwps63U9f8Q0TSN7fp/iK0PtuvviPjmrCHyR1qrICilNkTmHjZDLsDke/JzOtwnzY1KqXcR\nR4cFiBab9XlRT87I19dQSo1GNPz0tJOxHvR8mhrOVobB0XuAOBiWo1zmwaqdXW3X3x+4BzGVv4SM\npN9AnPEg21McxMIArTs2dRN4zoe26/8NOA6xGJwfbYqV9b8GnrM81Sz+Lz5A0qOXo2y4Ww3MoT4F\nIY4+KTfNF58TaXN4VthstVNDitLKcdxvOjKmEj0tv0M953fs87E3Eul0B2JliBflOzfwnFcA+iul\n5iEmwQFNEBaK569L0amUWggcqrXO8gg2FKHG2CdW4Uem9XvBlUflu7RUaiByU3lPa92ZKN8cSav8\nfUQBTHKr1rrqueIsxp18/eg1azrLjSYB6NfRsY3G6Is9nDjDYxh4zundvbMotvtm5N50duA5P09t\nT0faJIkfirU+zNrF1YiC4FBQECZE73/JqB//F+u14r+ImIVEOB1iu/6ZNfhwzEamp7YuU2e7RN1m\noZBnW5YVIfZ1qNWfotw51yuIph++hET0bAkcikwpTAEuCjxnSly3PzIP0a8NcnYgD6SBlSoaIhQX\nV2UtVup24LBU6S7IyG+NUuodZP52awojrTSvIjeshlij9XdQKh2jXYRRDtpGfOCruQfEpmzbdn0V\ndP9iPLsgjnEryI67Lzd/PCt6/5Tt+v3LJXAqQ/z7ut2ZO/Ccx23XfxUYZbt+7D8xCngl8Jwsa80s\nZBS8ke36O7cg4ybA5UgegJ0QE/XN5auvZRaiIMQRF12wXX8TCv9ls6eERpOtIMR+EXNS5YsRh8dS\nTo/V+CzUck21i6uR5++4wHNeKFXJRDH0PfoR5fqmtHKwDDhCa73O5JA3lCSeF04v6Z3FPRTMzBO7\nS6AE8Q12PbomgYn5Xpm29yMPhu2RUK96iKMn9q6zfa38JXo/NHoly7oQeM5K4Iro60+jKINuJVJC\nYu/439uuX805A4VkWyfbrp+V/MdFnOmeCmpfFKsSRYMc2/U/DeyG3OfSjpOx5WmfVHmcuXFcFfus\n5ZpqObbrb45EtswqpxyAcVI0FDMbOFxrXeT9a+heopvnEArzolvashT0wmbEapdgGpIU5XDb9R9F\nYqrXQyyL8wPPeTeuGHjOMtv1T0VuqldH6W//jigNmyHOcAcBgwPPcZog20xkRLcJ8DPb9S9CRqM7\nI7kDvoDE1hfdxwLPWWy7/plI7oCLbNffHXm4zUQeRtsjGRP/EXhOKSfcABkpj49i5+9G/putgHmB\n5yxIN4iSF21C14V6Rtiu/yYSW15uHv4a4P8oKAedlPcvOAv4KmItfCTKKfAS8v8NR1ILHwnsl5GA\nqF7ORdYaGA48HGWyfBqYgViDRwCfQR72PkDgOU9E2TvHI4m0TgeeRczb30DyH2iKcyA0ymrgWNv1\nFyDK1NvIQ3tStN3LCH+9HUl29UPb9echFo8BUbtLEKfJtJ9EmgA59ifbrj8bCR3cGDlvZqdTLcPa\n9NCbUMhs2GFLKvPFSAKxZl7/CxEL8pgoA+QMxD+kE3HenAHcHnjOGmNB6Dt8iGjHWSFKK4HHkcQr\nOxvloLXYrr+77fqrEIejNyiE6P0WccZbabv+lFLtG+Ry5AY/BHkYfRDtR9M79QAAA3FJREFUcwYS\nNdCFwHPuQR6a7wHfAR5GMhk+i9xcT6G6KIOKBJ6zFBn9r0GUmBlIWN9ziHf/5yjO/phsfy2yqt4i\nxOJxF3INTI9k/Q7ZoV4xv0PC5LZCci4sQm6g08kYHdquvxy5lt4DwsSmF5EENCts1//Idv3M9LbR\negJTkEx4NvBA1joFifqLIjkeR6wcfwdeQfIFTEEcjHNU79RXkShvw95Ixs5+yOj/KuSh+ATiAHcq\nxb4fxwOXRfJMQc6zlxGF6B3g4MBznmmWnBFzEUfP0xDFcCGiAG+JHKushESXIdanjRBF4l3EInAj\n8vuOqWK/5yNRGaOQFNkfIhkOX6CQgwAA2/W3jkI3V0T7ejjatAFyXb2PXP/LbVnroWGi6bbzo697\nIlaWk5Br93wkk+jztusP7o94Lna7eaoMZU0cVXIAped7eqGZfP2ZqmPFl+ptrVf3n19UpvVMYLRS\nagBywxuEjLwWAe9qrTMXV2mUzs7OP/Xrp+6qt33Hmn5Zue3XNeZTOVoky5nqKiQkrNT883Qk3WvJ\nsMLAc1bbrv9Z5AH6KWRkOB+5wRWlWo7a3Ga7/mOIomAho/GFyI30YeDREru7ELlOq07TG3jONbbr\nT0Nu9KOQm+i/gFsDz3nTdv2fI2FbpdpfHnlpH4LcnHdAlIz5yLErqXgFnvOR7fo28lDYE7lu3kKO\nTdZ9K52xrhTl7knnUVB6SqVeTsr4apQU6lDEbG4hCsFbROsRBE1ebjrwnNB2/XGIGf5gRBkYhPyv\n7yDpjR9MtVkOnGK7/vWIgrFrVPcF4O8ZKbaXIuduWkH6KfL/JbkEsWClfWK2CDzHt10/jzhXjkGO\nyzNIZEiRD00ga3ocaLv+kUh2xo8hSuVURKmIUyiXVGYCWVzKQlJD7xrJNg85b9LX8RLgF6X6SpFU\n9Cpe28gaJgORqEEAbNffDLlvHIQoAndR8NEYilwjExD/nwuUiTQ0GAwGw7qC7fqjEUvKqsBzmhWd\nt05gu/5pyNoifw48J9N5PForxQeeNFMMBoPBYDD0DWL/llvK1In9jt4zCoLBYDAYDH2DePo5MwrJ\ndv0hFPwTnjBRDAaDwWAw9A3+hPgOHRPl25iK+FhsiuR4OARx0Lwf+J1REAwGg8Fg6AMEnvNklL78\nHMRRca/E5hVINNIVwI2B56z6/3ExLRI31pXNAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image at 0x111275490>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import Image\n",
+    "Image(\"http://ipython.org/_static/IPy_header.png\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -70,9 +70,8 @@ def test_should_not_mutate(validator_name):
     assert nb.cells[3]["cell_type"] == "code"
 
     nb_deep_copy = deepcopy(nb)
-    with pytest.warns(None):
-        with pytest.raises(MissingIDFieldWarning):
-            validate(nb)
+    with pytest.raises(MissingIDFieldWarning):
+        validate(nb)
 
     assert nb == nb_deep_copy
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -290,7 +290,7 @@ def test_repair_non_unique_cell_ids():
     assert isvalid(nb)
 
 
-@pytest.mark.filterwarnings(MissingIDFieldWarning)
+@pytest.mark.filterwarnings("ignore::nbformat.warnings.MissingIDFieldWarning")
 def test_no_cell_ids():
     """Test that a cell without a cell ID does not pass validation"""
     import nbformat
@@ -305,7 +305,7 @@ def test_no_cell_ids():
         validate(nb, repair_duplicate_cell_ids=False)
 
 
-@pytest.mark.filterwarnings(MissingIDFieldWarning)
+@pytest.mark.filterwarnings("ignore::nbformat.warnings.MissingIDFieldWarning")
 def test_repair_no_cell_ids():
     """Test that we will repair cells without ids if asked during validation"""
     import nbformat

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -44,7 +44,6 @@ def test_should_warn(validator_name):
         nb = read(f, as_version=4)
 
     del nb.cells[3]["id"]
-    assert nb.cells[3].get("id") is None
     assert nb.cells[3]["cell_type"] == "code"
 
     nb_copy = deepcopy(nb)
@@ -59,7 +58,7 @@ def test_should_warn(validator_name):
 def test_should_not_mutate(validator_name):
     """Test that a v4 notebook without id raise an error and does/not mutate
 
-    Probably should be 2 test. To enable in the future.
+    Probably should be 2 distinct tests. To enable in the future.
     """
     set_validator(validator_name)
     with TestsBase.fopen("test4.5.ipynb", "r") as f:
@@ -75,7 +74,7 @@ def test_should_not_mutate(validator_name):
 
     assert nb == nb_deep_copy
 
-    assert isvalid(nb) is True
+    assert isvalid(nb) is False
 
 
 @pytest.mark.parametrize("validator_name", VALIDATORS)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -254,8 +254,6 @@ def test_fallback_validator_with_iter_errors_using_ref(recwarn):
     Test that when creating a standalone object (code_cell etc)
     the default validator is used as fallback.
     """
-    import nbformat
-
     set_validator("fastjsonschema")
     nbformat.v4.new_code_cell()
     nbformat.v4.new_markdown_cell()
@@ -265,8 +263,6 @@ def test_fallback_validator_with_iter_errors_using_ref(recwarn):
 
 def test_non_unique_cell_ids():
     """Test than a non-unique cell id does not pass validation"""
-    import nbformat
-
     with TestsBase.fopen("invalid_unique_cell_id.ipynb", "r") as f:
         # Avoids validate call from `.read`
         nb = nbformat.from_dict(json.load(f))
@@ -281,7 +277,6 @@ def test_non_unique_cell_ids():
 
 def test_repair_non_unique_cell_ids():
     """Test that we will repair non-unique cell ids if asked during validation"""
-    import nbformat
 
     with TestsBase.fopen("invalid_unique_cell_id.ipynb", "r") as f:
         # Avoids validate call from `.read`
@@ -294,7 +289,6 @@ def test_repair_non_unique_cell_ids():
 @pytest.mark.filterwarnings("ignore::nbformat.warnings.MissingIDFieldWarning")
 def test_no_cell_ids():
     """Test that a cell without a cell ID does not pass validation"""
-    import nbformat
 
     with TestsBase.fopen("v4_5_no_cell_id.ipynb", "r") as f:
         # Avoids validate call from `.read`
@@ -311,7 +305,6 @@ def test_no_cell_ids():
 @pytest.mark.filterwarnings("ignore::nbformat.warnings.MissingIDFieldWarning")
 def test_repair_no_cell_ids():
     """Test that we will repair cells without ids if asked during validation"""
-    import nbformat
 
     with TestsBase.fopen("v4_5_no_cell_id.ipynb", "r") as f:
         # Avoids validate call from `.read`

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -51,7 +51,7 @@ def test_should_warn(validator_name):
 
     with pytest.warns(MissingIDFieldWarning):
         validate(nb)
-    assert isvalid(nb) == True
+    assert isvalid(nb) is True
 
 
 @pytest.mark.xfail(reason="In the future we want to stop warning, and raise an error")
@@ -70,13 +70,13 @@ def test_should_not_mutate(validator_name):
     assert nb.cells[3]["cell_type"] == "code"
 
     nb_deep_copy = deepcopy(nb)
-
-    with (pytest.raises(MissingIDFieldWarning), pytest.warns(None)):
-        validate(nb)
+    with pytest.warns(None):
+        with pytest.raises(MissingIDFieldWarning):
+            validate(nb)
 
     assert nb == nb_deep_copy
 
-    assert isvalid(nb) == True
+    assert isvalid(nb) is True
 
 
 @pytest.mark.parametrize("validator_name", VALIDATORS)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -271,10 +271,12 @@ def test_non_unique_cell_ids():
         # Avoids validate call from `.read`
         nb = nbformat.from_dict(json.load(f))
     with pytest.raises(ValidationError):
-        validate(nb, repair_duplicate_cell_ids=False)
+        with pytest.warns(DeprecationWarning):
+            validate(nb, repair_duplicate_cell_ids=False)
     # try again to verify that we didn't modify the content
     with pytest.raises(ValidationError):
-        validate(nb, repair_duplicate_cell_ids=False)
+        with pytest.warns(DeprecationWarning):
+            validate(nb, repair_duplicate_cell_ids=False)
 
 
 def test_repair_non_unique_cell_ids():
@@ -298,10 +300,12 @@ def test_no_cell_ids():
         # Avoids validate call from `.read`
         nb = nbformat.from_dict(json.load(f))
     with pytest.raises(ValidationError):
-        validate(nb, repair_duplicate_cell_ids=False)
+        with pytest.warns(DeprecationWarning):
+            validate(nb, repair_duplicate_cell_ids=False)
     # try again to verify that we didn't modify the content
     with pytest.raises(ValidationError):
-        validate(nb, repair_duplicate_cell_ids=False)
+        with pytest.warns(DeprecationWarning):
+            validate(nb, repair_duplicate_cell_ids=False)
 
 
 @pytest.mark.filterwarnings("ignore::nbformat.warnings.MissingIDFieldWarning")
@@ -340,5 +344,6 @@ def test_strip_invalid_metadata():
     with TestsBase.fopen("v4_5_invalid_metadata.ipynb", "r") as f:
         nb = nbformat.from_dict(json.load(f))
     assert not isvalid(nb)
-    validate(nb, strip_invalid_metadata=True)
+    with pytest.warns(DeprecationWarning):
+        validate(nb, strip_invalid_metadata=True)
     assert isvalid(nb)


### PR DESCRIPTION
Re-issue of #236. #244 made things even worse with respect to some problem with notebook trust, 
where a notebook is trusted, saved, reopened  but is not trusted. 

The reason being that the signature is computed before validate, and validate mutate the notebook, leading to the signature not matching. 

really `validate()` _should not mutate the notebook ever_. Validate is in part used for security. It should not return a value of give results on a modified object. 

Just try to imagine if a password comparison function, said `compare('HUNTER@', 'hunter2') == True` because obviously the user had caps lock pressed on their keyboard ? This is the same.

We obviously can't change brutally, but we really need to stop having validation and normalisation be the same step.

