### PR TITLE
Fix and test auto version numbering.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -11,9 +11,9 @@ serialize =
 
 [bumpversion:part:release]
 optional_value = prod
-first_value = beta
+first_value = b
 values =
-	beta
+	b
 	prod
 
 [bumpversion:part:build]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: forbid-new-submodules
       - id: check-builtin-literals
       - id: trailing-whitespace
+        exclude: .bumpversion.cfg
 
   - repo: https://github.com/psf/black
     rev: 22.6.0

--- a/nbformat/_version.py
+++ b/nbformat/_version.py
@@ -4,6 +4,6 @@ version_info = (5, 4, 0)
 if len(version_info) <= 3:
     version_extra = ""
 else:
-    version_extra = version_info[3]
+    version_extra = version_info[3]  # type: ignore
 
 __version__ = ".".join(map(str, version_info[:3])) + version_extra

--- a/nbformat/_version.py
+++ b/nbformat/_version.py
@@ -1,3 +1,9 @@
 # Make sure to update package.json, too!
 version_info = (5, 4, 0)
-__version__ = ".".join(map(str, version_info))
+
+if len(version_info) <= 3:
+    version_extra = ""
+else:
+    version_extra = version_info[3]
+
+__version__ = ".".join(map(str, version_info[:3])) + version_extra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ test = [
     "check-manifest",
     "testpath",
     "pytest",
-    "pre-commit"
+    "pre-commit",
+    "pep440"
 ]
 
 [project.scripts]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,12 +10,18 @@ from tempfile import TemporaryDirectory
 from typing import Any, Dict
 
 from jsonschema import ValidationError
+from pep440 import is_canonical
 
+from nbformat import __version__ as nbf_version
 from nbformat import current_nbformat, read, write, writes
 from nbformat.reader import get_version
 from nbformat.validator import isvalid
 
 from .base import TestsBase
+
+
+def test_canonical_version():
+    assert is_canonical(nbf_version)
 
 
 class TestAPI(TestsBase):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 from typing import Any, Dict
 
 from jsonschema import ValidationError
-from pep440 import is_canonical
+from pep440 import is_canonical  # type: ignore
 
 from nbformat import __version__ as nbf_version
 from nbformat import current_nbformat, read, write, writes


### PR DESCRIPTION
Pep 440 mandate that the makers are `a`, `b`, `rc`, without dots.
Not beta/alpha. And `.dev` if present, must have a dot.

Otherwise this leads to problem in package resolutions where tgz can
appear to be more recent than whl of the same version...

This try to fix the version numbering scheme and test it.

It also skip whitespace trailing test on .bumpversoin.cfg at bum2version
itself  adds trailing spaces and try to commit which fails.