### PR TITLE
Only require nbformat_minor for v4

### DIFF
--- a/nbformat/v4/convert.py
+++ b/nbformat/v4/convert.py
@@ -40,10 +40,14 @@ def upgrade(nb, from_version=None, from_minor=None):
         from_version = nb["nbformat"]
     if not from_minor:
         if "nbformat_minor" not in nb:
-            raise validator.ValidationError(
-                "The notebook does not include the nbformat minor which is needed"
-            )
-        from_minor = nb["nbformat_minor"]
+            if from_version == 4:
+                raise validator.ValidationError(
+                    "The v4 notebook does not include the nbformat minor, which is needed."
+                )
+            else:
+                from_minor = 0
+        else:
+            from_minor = nb["nbformat_minor"]
 
     if from_version == 3:
         # Validate the notebook before conversion

--- a/tests/test3_no_min_version.ipynb
+++ b/tests/test3_no_min_version.ipynb
@@ -1,0 +1,12 @@
+{
+ "metadata": {
+  "name": ""
+ },
+ "nbformat": 3,
+ "worksheets": [
+  {
+   "metadata": {},
+   "cells": []
+  }
+ ]
+}

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -355,6 +355,12 @@ def test_notebook_invalid_without_min_version():
         validate(nb)
 
 
+def test_notebook_v3_valid_without_min_version():
+    with TestsBase.fopen("test3_no_min_version.ipynb", "r") as f:
+        nb = read(f, as_version=4)
+    validate(nb)
+
+
 def test_notebook_invalid_without_main_version():
     pass
 


### PR DESCRIPTION
#237 made some public notebooks unreadable. There is only one nbformat minor for v3, so there is no ambiguity here. It's more important for real notebooks to be readable than perfect validation be satisfied.

For example, this is linked from the nbviewer front page and started to fail because of #237: https://nbviewer.org/gist/fonnesbeck/2352771