### PR TITLE
Undeprecate validate(nb, relax_add_props=True)

### DIFF
--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -401,7 +401,7 @@ def validate(
     ref: Optional[str] = None,
     version: Optional[int] = None,
     version_minor: Optional[int] = None,
-    relax_add_props: bool = _deprecated,  # type: ignore
+    relax_add_props: bool = False,
     nbjson: Any = None,
     repair_duplicate_cell_ids: bool = _deprecated,  # type: ignore
     strip_invalid_metadata: bool = _deprecated,  # type: ignore
@@ -420,11 +420,10 @@ def validate(
     version : int
     version_minor : int
     relax_add_props : bool
-        Deprecated since 5.5.0 - will be removed in the future.
-        Wether to allow extra property in the Json schema validating the
-        notebook.
+        Wether to allow extra properties in the JSON schema validating the notebook.
+        When True, all known fields are validated, but unknown fields are ignored.
     nbjson
-    repair_duplicate_cell_ids : boolny
+    repair_duplicate_cell_ids : bool
         Deprecated since 5.5.0 - will be removed in the future.
     strip_invalid_metadata : bool
         Deprecated since 5.5.0 - will be removed in the future.
@@ -446,11 +445,6 @@ def validate(
     Please explicitly call `normalize` if you need to normalize notebooks.
     """
     assert isinstance(ref, str) or ref is None
-
-    if relax_add_props is _deprecated:
-        relax_add_props = False
-    else:
-        _dep_warn("relax_add_props")
 
     if strip_invalid_metadata is _deprecated:
         strip_invalid_metadata = False


### PR DESCRIPTION
There is no equivalent behavior in normalize, so I don't think this shouldn't have been deprecated along with the other normalizing steps. `relax_add_props` is purely related to validation, not normalization since no changes are made, it only changes what is checked. The case for it still exists and is still relevant (in nbconvert preprocessor validation), so I think it should be kept.

This change (respecting the deprecation in nbconvert) has caused notebooks to fail on nbviewer: https://nbviewer.org/github/ibtassam1/SQL_Vancouver/blob/03f9f1e5dbd2c3e13965c01d125f5c9ab371d696/Vancouver%20Public%20Services_v3.ipynb

Deprecation was added in #282