### PR TITLE
Only add ellipsis to NotJSONError message if message is truncated

### DIFF
--- a/nbformat/reader.py
+++ b/nbformat/reader.py
@@ -19,8 +19,11 @@ def parse_json(s, **kwargs):
     try:
         nb_dict = json.loads(s, **kwargs)
     except ValueError as e:
+        message = f"Notebook does not appear to be JSON: {s!r}"
         # Limit the error message to 80 characters.  Display whatever JSON will fit.
-        raise NotJSONError(("Notebook does not appear to be JSON: %r" % s)[:77] + "...") from e
+        if len(message) > 80:
+            message = message[:77] + "..."
+        raise NotJSONError(message) from e
     return nb_dict
 
 


### PR DESCRIPTION
In almost all cases, it will be truncated, but in the few cases that parse_json is called with short invalid inputs, this prevents confusion about what actually got passed in.

Specifically, I ran into a case where nbformat was getting an empty string, rather than a valid JSON string, which produced the message
> Notebook does not appear to be JSON: ''...
which wrongly implies there is more to the input than there was.

It's a minor issue for sure, but I was poking around here anyway, so I thought I'd fix it.