### PR TITLE
Add strip_invalid_metadata argument to validator normalize method

### DIFF
--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -264,6 +264,7 @@ def normalize(
     version_minor: Optional[int] = None,
     *,
     relax_add_props: bool = False,
+    strip_invalid_metadata: bool = False,
 ) -> Tuple[int, Any]:
     """
     Normalise a notebook prior to validation.
@@ -282,8 +283,11 @@ def normalize(
     version : int
     version_minor : int
     relax_add_props : bool
-        Wether to allow extra property in the Json schema validating the
+        Whether to allow extra property in the Json schema validating the
         notebook.
+    strip_invalid_metadata : bool
+        Whether to strip metadata that does not exist in the Json schema when
+        validating the notebook.
 
     Returns
     -------
@@ -305,7 +309,7 @@ def normalize(
         version_minor,
         True,
         relax_add_props=relax_add_props,
-        strip_invalid_metadata=False,
+        strip_invalid_metadata=strip_invalid_metadata,
     )
 
 


### PR DESCRIPTION
:wave: This update adds the `strip_invalid_metadata` argument to the public `normalize` method, passing the argument into the nonpublic `_normalize` method rather than always passing false.

The reason behind this change is that the _normalize method [only uses the `relax_add_props` argument when `strip_invalid_metadata` is true](https://github.com/jupyter/nbformat/blob/3bc1b535f40b55961fd3b44ff1b38df05e0a9eda/nbformat/validator.py#L374-L377).  That argument is currently hardcoded to false by `normalize`, making the `relax_add_props` argument functionality unused.  By allowing callers to specify `strip_invalid_metadata`, there is at least a chance that the `relax_add_prop` argument will also be used.

I didn't see any tests in this project related to the normalize method, so I wasn't sure what might be needed for tests.