### PR TITLE
Fix deprecation warning when importing from jsonschema

### DIFF
--- a/nbformat/json_compat.py
+++ b/nbformat/json_compat.py
@@ -11,7 +11,7 @@ import fastjsonschema
 import jsonschema
 from fastjsonschema import JsonSchemaException as _JsonSchemaException
 from jsonschema import Draft4Validator as _JsonSchemaValidator
-from jsonschema import ErrorTree, ValidationError
+from jsonschema.exceptions import ErrorTree, ValidationError
 
 
 class JsonSchemaValidator:

--- a/nbformat/json_compat.py
+++ b/nbformat/json_compat.py
@@ -55,7 +55,7 @@ class FastJsonSchemaValidator(JsonSchemaValidator):
     def validate(self, data):
         """Validate incoming data."""
         try:
-            self._validator(data)
+            self._validator(data)  # type:ignore[operator]
         except _JsonSchemaException as error:
             raise ValidationError(str(error), schema_path=error.path) from error
 
@@ -67,7 +67,7 @@ class FastJsonSchemaValidator(JsonSchemaValidator):
         errors = []
         validate_func = self._validator
         try:
-            validate_func(data)
+            validate_func(data)  # type:ignore[operator]
         except _JsonSchemaException as error:
             errors = [ValidationError(str(error), schema_path=error.path)]
 


### PR DESCRIPTION
`jsonschema` v4.18.0 deprecated
importing of `jsonschema.ErrorTree`
instead import it via `jsonschema.exceptions.ErrorTree`
 
 https://github.com/python-jsonschema/jsonschema/releases/tag/v4.18.0
 
 This to avoid warning raised:
```
 /usr/local/lib/python3.8/site-packages/nbformat/json_compat.py:14:Importing ErrorTree directly from the jsonschema package is deprecated and will become an ImportError. Import it from jsonschema.exceptions instead.
/usr/local/lib/python3.8/site-packages/nbformat/json_compat.py:14:Importing ErrorTree directly from the jsonschema package is deprecated and will become an ImportError. Import it from jsonschema.exceptions instead.
```

 