### PR TITLE
Improve project URLs that display on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ content-type = "text/plain"
 
 [project.urls]
 Homepage = "https://jupyter.org"
+Changelog = "https://github.com/jupyter/nbformat/blob/main/CHANGELOG.md"
+Documentation = "https://nbformat.readthedocs.io/"
+Repository = "https://github.com/jupyter/nbformat.git"
+
 
 [project.optional-dependencies]
 docs = [


### PR DESCRIPTION
This transforms the [nbformat page on PyPI](https://pypi.org/project/nbformat/) from this:

<img width="295" alt="Screenshot 2023-08-01 at 3 25 51 PM" src="https://github.com/jupyter/nbformat/assets/62857/5696d10d-a19a-4d02-bb28-3d3e70fa94d8">

to something like this, although issues will instead be a direct link to the Git repo:

<img width="319" alt="Screenshot 2023-08-01 at 3 27 28 PM" src="https://github.com/jupyter/nbformat/assets/62857/b60e0859-b85b-46ee-a1c9-9c1a61301480">

