### PR TITLE
Simplify NotebookNotary._data_dir_default

### DIFF
--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -37,8 +37,9 @@ except ImportError:
 from base64 import encodebytes
 
 from jupyter_core.application import JupyterApp, base_flags
+from jupyter_core.paths import jupyter_data_dir
 from traitlets import Any, Bool, Bytes, Callable, Enum, Instance, Integer, Unicode, default, observe
-from traitlets.config import LoggingConfigurable, MultipleInstanceError
+from traitlets.config import LoggingConfigurable
 
 from . import NO_CONVERT, __version__, read, reads
 
@@ -341,17 +342,7 @@ class NotebookNotary(LoggingConfigurable):
 
     @default("data_dir")
     def _data_dir_default(self):
-        app = None
-        try:
-            if JupyterApp.initialized():
-                app = JupyterApp.instance()
-        except MultipleInstanceError:
-            pass
-        if app is None:
-            # create an app, without the global instance
-            app = JupyterApp()
-            app.initialize(argv=[])
-        return app.data_dir
+        return jupyter_data_dir()
 
     store_factory = Callable(
         help="""A callable returning the storage backend for notebook signatures.


### PR DESCRIPTION
The code for that function originally predates the introduction of the function `jupyter_core.paths.jupyter_data_dir` which can now be used to determine the Jupyter data directory instead of initializing an instance of JupyterApp just to figure its data directory.

I figure this out while working on another PR for jupyter_server_fileid which uses the function to determine the data directory : https://github.com/jupyter-server/jupyter_server_fileid/blob/v0.9.0/jupyter_server_fileid/manager.py#L23
