### PR TITLE
Fix malformed schema in v4.5

### DIFF
--- a/nbformat/v4/nbformat.v4.5.schema.json
+++ b/nbformat/v4/nbformat.v4.5.schema.json
@@ -211,13 +211,15 @@
               "description": "Official Jupyter Metadata for Code Cells",
               "type": "object",
               "additionalProperties": true,
-              "source_hidden": {
-                "description": "Whether the source is hidden.",
-                "type": "boolean"
-              },
-              "outputs_hidden": {
-                "description": "Whether the outputs are hidden.",
-                "type": "boolean"
+              "properties: {
+                "source_hidden": {
+                  "description": "Whether the source is hidden.",
+                  "type": "boolean"
+                },
+                "outputs_hidden": {
+                  "description": "Whether the outputs are hidden.",
+                  "type": "boolean"
+                }
               }
             },
             "execution": {


### PR DESCRIPTION
currently the `/defintions/code_cell/properties/metadata/properties/jupyter` definition is malformed. `source_hidden` and `outputs_hidden` need to within a `properties` scope. 

this initial pull request show the change in v4.5 schema. i'd love some advice about how best fix this in the code base. i'm not sure what schema should be changed or the process to fix a verified schema. do we increment versions?