### PR TITLE
Update rwbase.py: fix edge case

### DIFF
--- a/nbformat/v4/rwbase.py
+++ b/nbformat/v4/rwbase.py
@@ -3,6 +3,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 from __future__ import annotations
+from collections.abc import Mapping
 
 
 def _is_json_mime(mime):
@@ -97,6 +98,10 @@ def strip_transient(nb):
 
     This should be called in *both* read and write.
     """
+    # Handle malformed notebooks where metadata was incorrectly set as a non-dictionary type
+    if not isinstance(nb.metadata, Mapping):
+        nb.metadata = dict()
+    
     nb.metadata.pop("orig_nbformat", None)
     nb.metadata.pop("orig_nbformat_minor", None)
     nb.metadata.pop("signature", None)


### PR DESCRIPTION
Notebooks exported from org-mode (emacs) set the metadata as a list. With this change, the corrupt metadata is discarded.