### PR TITLE
Drop pep440 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "testpath",
     "pytest",
     "pre-commit",
-    "pep440"
+    "packaging"
 ]
 
 [project.scripts]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 from jsonschema import ValidationError
-from pep440 import is_canonical
+from packaging import version
 
 from nbformat import __version__ as nbf_version
 from nbformat import current_nbformat, read, write, writes
@@ -22,7 +22,7 @@ from .base import TestsBase
 
 
 def test_canonical_version():
-    assert is_canonical(nbf_version)
+    assert str(version.parse(nbf_version)) == nbf_version
 
 
 class TestAPI(TestsBase):


### PR DESCRIPTION
Just a random drive-by PR. Noticed from `python-pep440` being orphaned on Fedora that there are some packages that still require it, this being one of them. In principle `packaging` should be used instead of all of these kind of projects moving forward.

In this case it is likely that this is not needed at all and `hatch-nodejs-version` would take care of it automatically, but I did not confirm it, so I've left the test as-is for now.