### PR TITLE
fix typo with quotes in docs

### DIFF
--- a/docs/format_description.rst
+++ b/docs/format_description.rst
@@ -302,7 +302,7 @@ regardless of format.
             # nbconvert to formats other than this will exclude this cell.
             "format": "mime/type"
         },
-        "source": "[some nbformat output text]",
+        "source": ["some nbformat output text"],
     }
 
 


### PR DESCRIPTION
fixes minor typo where quotes are improperly outside the brackets rather than inside