### PR TITLE
test: ensure validate does not mutate invalid notebooks

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -274,6 +274,7 @@ def test_invalid_validator_raises_value_error_after_read():
     with pytest.raises(ValueError):
         validate(nb)
 
+
 @pytest.mark.parametrize("validator_name", VALIDATORS)
 def test_validate_does_not_mutate_invalid_notebook(validator_name):
     set_validator(validator_name)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -274,6 +274,19 @@ def test_invalid_validator_raises_value_error_after_read():
     with pytest.raises(ValueError):
         validate(nb)
 
+@pytest.mark.parametrize("validator_name", VALIDATORS)
+def test_validate_does_not_mutate_invalid_notebook(validator_name):
+    set_validator(validator_name)
+    with TestsBase.fopen("invalid.ipynb", "r") as f:
+        nb = read(f, as_version=4)
+
+    original = deepcopy(nb)
+
+    with pytest.raises(ValidationError):
+        validate(nb)
+
+    assert nb == original
+
 
 def test_fallback_validator_with_iter_errors_using_ref(recwarn):
     """


### PR DESCRIPTION
Adds a focused regression test ensuring that nbformat.validate() does not mutate an invalid notebook object when validation fails.

This complements existing mutation-related tests and provides a stable invariant check using invalid.ipynb.
