### PR TITLE
Update notebook version metadata during normalize

### DIFF
--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -313,7 +313,7 @@ def normalize(
         version = nbdict_version
     if version_minor is None:
         version_minor = nbdict_version_minor
-    return _normalize(
+    changes, normalized_nb = _normalize(
         nbdict,
         version,
         version_minor,
@@ -321,6 +321,11 @@ def normalize(
         relax_add_props=relax_add_props,
         strip_invalid_metadata=strip_invalid_metadata,
     )
+    if "nbformat" in normalized_nb:
+        normalized_nb["nbformat"] = version
+    if "nbformat_minor" in normalized_nb:
+        normalized_nb["nbformat_minor"] = version_minor
+    return changes, normalized_nb
 
 
 def _normalize(

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -15,7 +15,7 @@ from jsonschema import ValidationError
 import nbformat
 from nbformat import read
 from nbformat.json_compat import VALIDATORS
-from nbformat.validator import isvalid, iter_validate, validate
+from nbformat.validator import isvalid, iter_validate, normalize, validate
 from nbformat.warnings import DuplicateCellId, MissingIDFieldWarning
 
 from .base import TestsBase
@@ -369,8 +369,33 @@ def test_notebook_v3_valid_without_min_version():
     validate(nb)
 
 
-def test_notebook_invalid_without_main_version():
-    pass
+@pytest.mark.filterwarnings("ignore::nbformat.warnings.MissingIDFieldWarning")
+def test_normalize_updates_minor_version():
+    """Normalizing to v4.5 should update notebook metadata version."""
+
+    nb = {
+        "nbformat": 4,
+        "nbformat_minor": 0,
+        "metadata": {},
+        "cells": [
+            {
+                "cell_type": "code",
+                "metadata": {},
+                "source": "",
+                "outputs": [],
+                "execution_count": None,
+            }
+        ],
+    }
+
+    changes, new_nb = normalize(nb, version_minor=5)
+
+    assert changes == 1
+    assert "id" in new_nb["cells"][0]
+
+    # Expected notebook version metadata
+    assert new_nb["nbformat"] == 4
+    assert new_nb["nbformat_minor"] == 5
 
 
 def test_strip_invalid_metadata():


### PR DESCRIPTION
## Summary

Updates `nbformat.validator.normalize()` to synchronize notebook version metadata with the target version used during normalization.

Previously, normalizing a notebook to a newer schema version could introduce fields that are only valid in that version (for example, cell IDs introduced in notebook format 4.5) while leaving `nbformat_minor` unchanged. This could produce a notebook whose contents no longer matched the version declared in its metadata.

## Changes

- Update `normalize()` to set:
  - `nbformat = version`
  - `nbformat_minor = version_minor`
- Add a regression test covering normalization from v4.0 to v4.5

## Motivation

Addresses #328.

The issue discussion notes that when normalization upgrades a notebook to a newer schema version, the notebook metadata should also be updated to reflect the version used during normalization.

## Testing

```bash
pytest