### PR TITLE
Add context manager support to NotebookNotary

### DIFF
--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -8,6 +8,7 @@ import hashlib
 import os
 import sys
 import typing as t
+import warnings
 from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -332,6 +333,40 @@ def signature_removed(nb):
             nb["metadata"]["signature"] = save_signature
 
 
+class NotebookNotaryContext(t.Protocol):
+    """The operations available on a :class:`NotebookNotary` used as a context manager.
+
+    This is what ``NotebookNotary.__enter__`` returns. It deliberately omits
+    ``close()``, ``__enter__``, and ``__exit__`` so that a type checker flags
+    attempts to close or re-enter the notary from within its own ``with``
+    block.
+    """
+
+    def compute_signature(self, nb: t.Any) -> str:
+        """Compute a notebook's signature."""
+        ...
+
+    def check_signature(self, nb: t.Any) -> bool:
+        """Check a notebook's stored signature."""
+        ...
+
+    def sign(self, nb: t.Any) -> None:
+        """Sign a notebook, indicating that its output is trusted on this machine."""
+        ...
+
+    def unsign(self, nb: t.Any) -> None:
+        """Ensure that a notebook is untrusted."""
+        ...
+
+    def mark_cells(self, nb: t.Any, trusted: bool) -> None:
+        """Mark cells as trusted if the notebook's signature can be verified."""
+        ...
+
+    def check_cells(self, nb: t.Any) -> bool:
+        """Return whether all code cells are trusted."""
+        ...
+
+
 class NotebookNotary(LoggingConfigurable):
     """A class for computing and verifying notebook signatures."""
 
@@ -424,6 +459,45 @@ class NotebookNotary(LoggingConfigurable):
         """Initialize the notary."""
         super().__init__(**kwargs)
         self.store = self.store_factory()
+        self._used_as_context_manager = False
+        self._warned_not_context_manager = False
+
+    def close(self):
+        """Close the notary's signature store.
+
+        Should be called when the notary is no longer needed, to release
+        any resources (e.g. database connections) held by the store.
+        """
+        self.store.close()
+
+    def __enter__(self) -> NotebookNotaryContext:
+        """Enter the notary's context, marking it as used within a `with` block."""
+        self._used_as_context_manager = True
+        return self
+
+    def __exit__(self, *exc_info):
+        """Exit the notary's context, closing its signature store."""
+        self.close()
+
+    def _warn_if_not_context_manager(self):
+        """Warn once if the store is accessed without using this notary as a context manager.
+
+        Using ``NotebookNotary`` outside of a ``with`` block is deprecated as
+        of nbformat 5.11, since it makes it easy to forget to release the
+        resources (e.g. database connections) held by the store.
+        """
+        if self._used_as_context_manager or self._warned_not_context_manager:
+            return
+        self._warned_not_context_manager = True
+        warnings.warn(
+            "Using NotebookNotary without a `with` block is deprecated as of "
+            "nbformat 5.11. Use it as a context manager instead, e.g.:\n\n"
+            "    with NotebookNotary() as notary:\n"
+            "        notary.sign(nb)\n\n"
+            "so that the underlying signature store is properly closed.",
+            PendingDeprecationWarning,
+            stacklevel=3,
+        )
 
     def _write_secret_file(self, secret):
         """write my secret to my secret_file"""
@@ -464,6 +538,7 @@ class NotebookNotary(LoggingConfigurable):
         - the requested scheme is available from hashlib
         - the computed hash from notebook_signature matches the stored hash
         """
+        self._warn_if_not_context_manager()
         if nb.nbformat < 3:
             return False
         signature = self.compute_signature(nb)
@@ -474,6 +549,7 @@ class NotebookNotary(LoggingConfigurable):
 
         Stores hash algorithm and hmac digest in a local database of trusted notebooks.
         """
+        self._warn_if_not_context_manager()
         if nb.nbformat < 3:
             return
         signature = self.compute_signature(nb)
@@ -484,6 +560,7 @@ class NotebookNotary(LoggingConfigurable):
 
         by removing its signature from the trusted database, if present.
         """
+        self._warn_if_not_context_manager()
         signature = self.compute_signature(nb)
         self.store.remove_signature(signature, self.algorithm)
 
@@ -624,21 +701,22 @@ class TrustNotebookApp(JupyterApp):
 
     def start(self):
         """Start the trust notebook app."""
-        if self.reset:
-            if Path(self.notary.db_file).exists():
-                print("Removing trusted signature cache: %s" % self.notary.db_file)  # noqa: T201
-                Path(self.notary.db_file).unlink()
-            self.generate_new_key()
-            return
-        if not self.extra_args:
-            self.log.debug("Reading notebook from stdin")
-            nb_s = sys.stdin.read()
-            assert isinstance(nb_s, str)
-            nb = reads(nb_s, NO_CONVERT)
-            self.sign_notebook(nb, "<stdin>")
-        else:
-            for notebook_path in self.extra_args:
-                self.sign_notebook_file(notebook_path)
+        with self.notary:
+            if self.reset:
+                if Path(self.notary.db_file).exists():
+                    print("Removing trusted signature cache: %s" % self.notary.db_file)  # noqa: T201
+                    Path(self.notary.db_file).unlink()
+                self.generate_new_key()
+                return
+            if not self.extra_args:
+                self.log.debug("Reading notebook from stdin")
+                nb_s = sys.stdin.read()
+                assert isinstance(nb_s, str)
+                nb = reads(nb_s, NO_CONVERT)
+                self.sign_notebook(nb, "<stdin>")
+            else:
+                for notebook_path in self.extra_args:
+                    self.sign_notebook_file(notebook_path)
 
 
 main = TrustNotebookApp.launch_instance

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -12,8 +12,10 @@ import sys
 import tempfile
 import time
 import unittest
+import warnings
 from subprocess import PIPE, Popen
 
+import pytest
 import testpath
 from traitlets.config import Config
 
@@ -30,13 +32,14 @@ class TestNotary(TestsBase):
             secret=b"secret",
             data_dir=self.data_dir,
         )
+        self.notary.__enter__()
         with self.fopen("test3.ipynb", "r") as f:
             self.nb = read(f, as_version=4)
         with self.fopen("test3.ipynb", "r") as f:
             self.nb3 = read(f, as_version=3)
 
     def tearDown(self):
-        self.notary.store.close()
+        self.notary.__exit__(None, None, None)
         shutil.rmtree(self.data_dir)
 
     def test_invalid_db_file(self):
@@ -44,15 +47,42 @@ class TestNotary(TestsBase):
         with open(invalid_sql_file, "w", encoding="utf-8") as tempfile:
             tempfile.write("[invalid data]")
 
-        invalid_notary = sign.NotebookNotary(
+        with sign.NotebookNotary(
             db_file=invalid_sql_file,
             secret=b"secret",
-        )
-        invalid_notary.sign(self.nb)
-        invalid_notary.store.close()
+        ) as invalid_notary:
+            invalid_notary.sign(self.nb)
 
         testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file))
         testpath.assert_isfile(os.path.join(self.data_dir, invalid_sql_file + ".bak"))
+
+    def test_not_using_context_manager_warns(self):
+        """Using the store without entering the notary as a context manager warns once."""
+        notary = sign.NotebookNotary(
+            db_file=":memory:",
+            secret=b"secret",
+            data_dir=self.data_dir,
+        )
+        try:
+            with pytest.warns(PendingDeprecationWarning, match="context manager"):
+                notary.sign(self.nb)
+            # only warns once per instance
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                notary.check_signature(self.nb)
+        finally:
+            notary.close()
+
+    def test_using_context_manager_does_not_warn(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with sign.NotebookNotary(
+                db_file=":memory:",
+                secret=b"secret",
+                data_dir=self.data_dir,
+            ) as notary:
+                notary.sign(self.nb)
+                self.assertTrue(notary.check_signature(self.nb))
 
     def test_algorithms(self):
         last_sig = ""


### PR DESCRIPTION
`NotebookNotary` owns a `SignatureStore` (e.g. an SQLite connection) that must be closed explicitly. This PR adds context manager support and nudges callers towards it.

1. **Add context manager support to `NotebookNotary`** — `close()`/`__enter__`/`__exit__` so it can be used as `with NotebookNotary() as notary: ...` to release the underlying resources automatically.
2. **Warn when `NotebookNotary` is used without a context manager** — `sign()`/`check_signature()`/`unsign()` emit a `PendingDeprecationWarning` (once per instance) if the notary was never entered via `with`, deprecated as of nbformat 5.11. `TrustNotebookApp` and the test suite are updated to use `with` and stay warning-free.
3. **Narrow the type of `__enter__`'s return value** — a `NotebookNotaryContext` `Protocol` covering just the sign/check operations, so type checkers flag calling `close()`/`__enter__`/`__exit__` from within a `with` block. Runtime behavior is unchanged (`__enter__` still returns `self`).
