### PR TITLE
Add Python 3.14 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,17 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.14"]
-        include:
-          - os: windows-latest
-            python-version: "3.9"
-          - os: ubuntu-latest
-            python-version: "3.11"
-          - os: macos-latest
-            python-version: "3.10"
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v5
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_package_manager: "uv pip"
       - name: Run the tests
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: |
@@ -61,6 +56,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_package_manager: "uv pip"
       - name: Run Linters
         run: |
           hatch run typing:test
@@ -73,6 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_package_manager: "uv pip"
       - name: Test docs
         run: hatch run docs:build
 
@@ -86,6 +85,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: minimum
+          python_package_manager: "uv pip"
       - name: Run the unit tests
         run: |
           hatch run test:nowarn || hatch run test:nowarn --lf
@@ -101,6 +101,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: pre
+          python_package_manager: "uv pip"
       - name: Run the tests
         run: |
           hatch run test:nowarn || hatch run test:nowarn --lf
@@ -112,6 +113,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_package_manager: "uv pip"
       - uses: jupyterlab/maintainer-tools/.github/actions/make-sdist@v1
 
   test_sdist:
@@ -121,6 +124,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_package_manager: "uv pip"
       - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
 
   check_release:
@@ -130,9 +135,11 @@ jobs:
         uses: actions/checkout@v5
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_package_manager: "uv pip"
       - name: Install Dependencies
         run: |
-          pip install -e .
+          uv pip install --system -e .
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
@@ -145,6 +152,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_package_manager: "uv pip"
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_glob: "tests/*.ipynb"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.9", "3.14"]
         include:
           - os: windows-latest
             python-version: "3.9"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v5
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,6 @@ python:
       extra_requirements:
         - docs
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.14"

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -81,7 +81,7 @@ Notebook signatures
 
 This machinery is used by the notebook web application to record which notebooks
 are *trusted*, and may show dynamic output as soon as they're loaded. See
-:ref:`server:server_security` for more information.
+:ref:`jupyter-server:server_security` for more information.
 
 .. autoclass:: NotebookNotary
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -304,7 +304,7 @@ texinfo_documents = [
 
 
 intersphinx_mapping = get_intersphinx_mapping(
-    packages={"python", "jupyterclient", "nbconvert", "notebook", "server"}
+    packages={"python", "jupyterclient", "nbconvert", "notebook", "jupyter-server"}
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13"
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
 requires-python = ">=3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,13 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "fastjsonschema>=2.15",
     "jsonschema>=2.6",
@@ -138,7 +137,7 @@ exclude_lines = [
 
 [tool.mypy]
 files = "nbformat"
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 disable_error_code = ["no-untyped-def", "no-untyped-call"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ jupyter-trust = "nbformat.sign:TrustNotebookApp.launch_instance"
 [tool.hatch.version]
 source = "nodejs"
 
+[tool.hatch.envs.default]
+installer = "uv"
+
 [tool.hatch.envs.docs]
 features = ["docs"]
 [tool.hatch.envs.docs.scripts]
@@ -87,6 +90,7 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.lint]
 detached = true
+installer = "uv"
 dependencies = ["pre-commit"]
 [tool.hatch.envs.lint.scripts]
 build = [
@@ -97,6 +101,7 @@ build = [
 [tool.hatch.envs.typing]
 dependencies = [ "pre-commit"]
 detached = true
+installer = "uv"
 [tool.hatch.envs.typing.scripts]
 test = "pre-commit run --all-files --hook-stage manual mypy"
 

--- a/tests/v3/test_nbpy.py
+++ b/tests/v3/test_nbpy.py
@@ -27,7 +27,7 @@ class TestPy(formattest.NBFormatTest, TestCase):
                 self.assertTrue(k in db)
                 self.assertSubset(v, db[k])
         elif isinstance(da, list):
-            for a, b in zip(da, db):
+            for a, b in zip(da, db, strict=False):
                 self.assertSubset(a, b)
         else:
             if isinstance(da, str) and isinstance(db, str):


### PR DESCRIPTION
Bump the max tested Python version from 3.13 to 3.14 in the test
matrix and add the corresponding trove classifier.