### PR TITLE
Bump pre-commit hook pins and fix resulting lint/typing fallout

### DIFF
--- a/.github/scripts/parse_ref.py
+++ b/.github/scripts/parse_ref.py
@@ -24,7 +24,7 @@ def parse_ref(current_ref):
     """
     if not current_ref.startswith("refs/tags/"):
         msg = f"Invalid ref `{current_ref}`!"
-        raise Exception(msg)
+        raise ValueError(msg)
 
     tag_name = current_ref.replace("refs/tags/", "")
     print(tag_name)  # noqa: T201

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.34.0
+    rev: 0.37.4
     hooks:
       - id: check-github-workflows
 
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
 
@@ -40,10 +40,10 @@ repos:
     rev: "1.20.0"
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==23.7.0]
+        additional_dependencies: [black==26.5.1]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.4.1"
+    rev: "v2.4.3"
     hooks:
       - id: codespell
         args: ["-L", "sur,nd,assertin"]
@@ -56,7 +56,7 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.18.2"
+    rev: "v2.3.0"
     hooks:
       - id: mypy
         files: "^nbformat"
@@ -65,7 +65,7 @@ repos:
           ["jsonschema>=2.6", "traitlets>=5.13", "jupyter_core>5.4"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.3
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         types_or: [python, jupyter]

--- a/nbformat/__init__.py
+++ b/nbformat/__init__.py
@@ -42,12 +42,12 @@ versions = {
     4: v4,
 }
 
-from . import reader  # noqa: E402
-from .converter import convert  # noqa: E402
-from .notebooknode import NotebookNode, from_dict  # noqa: E402
-from .v4 import nbformat as current_nbformat  # noqa: E402
-from .v4 import nbformat_minor as current_nbformat_minor  # noqa: E402
-from .validator import ValidationError, validate  # noqa: E402
+from . import reader
+from .converter import convert
+from .notebooknode import NotebookNode, from_dict
+from .v4 import nbformat as current_nbformat
+from .v4 import nbformat_minor as current_nbformat_minor
+from .validator import ValidationError, validate
 
 
 class NBFormatError(ValueError):

--- a/nbformat/v2/convert.py
+++ b/nbformat/v2/convert.py
@@ -61,4 +61,4 @@ def downgrade(nb):
         The Python representation of the notebook to convert.
     """
     msg = "Downgrade from notebook v2 to v1 is not supported."
-    raise Exception(msg)
+    raise RuntimeError(msg)

--- a/nbformat/v2/nbxml.py
+++ b/nbformat/v2/nbxml.py
@@ -20,14 +20,14 @@ https://github.com/jupyter/nbformat/issues/132
 
 def reads(s, **kwargs):
     """REMOVED"""
-    raise Exception(REMOVED_MSG)
+    raise RuntimeError(REMOVED_MSG)
 
 
 def read(fp, **kwargs):
     """REMOVED"""
-    raise Exception(REMOVED_MSG)
+    raise RuntimeError(REMOVED_MSG)
 
 
 def to_notebook(root, **kwargs):
     """REMOVED"""
-    raise Exception(REMOVED_MSG)
+    raise RuntimeError(REMOVED_MSG)

--- a/nbformat/v3/nbbase.py
+++ b/nbformat/v3/nbbase.py
@@ -45,7 +45,7 @@ def str_passthrough(obj):
     Used to be cast_unicode, add this temporarily to make sure no further breakage.
     """
     if not isinstance(obj, str):
-        raise AssertionError
+        raise TypeError
     return obj
 
 
@@ -62,7 +62,7 @@ def cast_str(obj):
         )
         return obj.decode("ascii", "replace")
     if not isinstance(obj, str):
-        raise AssertionError
+        raise TypeError
     return obj
 
 

--- a/nbformat/v4/rwbase.py
+++ b/nbformat/v4/rwbase.py
@@ -39,7 +39,7 @@ def rejoin_lines(nb):
             cell.source = "".join(cell.source)
 
         attachments = cell.get("attachments", {})
-        for _, attachment in attachments.items():
+        for attachment in attachments.values():
             _rejoin_mimebundle(attachment)
 
         if cell.get("cell_type", None) == "code":
@@ -80,7 +80,7 @@ def split_lines(nb):
             cell["source"] = source.splitlines(True)
 
         attachments = cell.get("attachments", {})
-        for _, attachment in attachments.items():
+        for attachment in attachments.values():
             _split_mimebundle(attachment)
 
         if cell.cell_type == "code":

--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -19,7 +19,7 @@ from .json_compat import ValidationError, _validator_for_name, get_current_valid
 from .reader import get_version
 from .warnings import DuplicateCellId, MissingIDFieldWarning
 
-validators = {}
+validators: dict[tuple[str, int | None, int | None], Any] = {}
 _deprecated = object()
 
 
@@ -261,7 +261,7 @@ def better_validation_error(error, version, version_minor):
                 if better.ref is None:
                     better.ref = ref
                 return better
-            except Exception:  # noqa: S110
+            except Exception:  # noqa: S110, BLE001
                 # if it fails for some reason,
                 # let the original error through
                 pass

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -219,7 +219,7 @@ class TestNotary(TestsBase):
         def sign_stdin(nb):
             env = os.environ.copy()
             env["JUPYTER_DATA_DIR"] = self.data_dir
-            p = Popen(  # noqa: S603
+            p = Popen(
                 [sys.executable, "-m", "nbformat.sign", "--log-level=0"],
                 stdin=PIPE,
                 stdout=PIPE,

--- a/tests/v4/nbexamples.py
+++ b/tests/v4/nbexamples.py
@@ -35,7 +35,7 @@ cells.append(
         source="Cell with attachments",
         attachments={
             "attachment1": {
-                "text/plain": "\n".join(["a", "b", "c"]),
+                "text/plain": "a\nb\nc",
                 "application/vnd.stuff+json": ["a", 1, "x"],
             }
         },


### PR DESCRIPTION
Updates ruff, mypy, check-jsonschema, mdformat, blacken-docs (black),
and codespell to their latest revs, and fixes the new issues each
bump surfaces: ruff's newer rule mappings (TRY002/TRY004/PERF102/
BLE001/RUF100/FLY002) and mypy 2.x's stricter var-annotated check on
the module-level `
validators` dict.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: 
https://claude.ai/code/session_01XZMyEvBjPXXmutJQkYdzcG