### PR TITLE
Fix validators cache key type annotation

### DIFF
--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -20,7 +20,7 @@ from .json_compat import ValidationError, _validator_for_name, get_current_valid
 from .reader import get_version
 from .warnings import DuplicateCellId, MissingIDFieldWarning
 
-validators: dict[tuple[str, int | None, int | None], Any] = {}
+validators: dict[tuple[str, int | None, int | None, bool], Any] = {}
 _deprecated = object()
 
 


### PR DESCRIPTION
`main`@4421827 ("Bump pre-commit hook pins and fix resulting lint/typing fallout") annotated the module-level cache as `validators: dict[tuple[str, int | None, int | None], Any] = {}`, but an earlier commit (89495c3, "Speed up deepcopy and stop draining validation errors eagerly") had already widened the actual key built at `get_validator` to a 4-tuple by appending `relax_add_props`. The 3-tuple annotation and the 4-tuple runtime key disagree, so `mypy --strict` fails on `main` itself:

```
nbformat/validator.py:77: error: Non-overlapping container check (element type: "tuple[Any, Any, Any, Any]", container item type: "tuple[str, int | None, int | None]")  [comparison-overlap]
nbformat/validator.py:94: error: Invalid index type "tuple[Any, Any, Any, Any]" for "dict[tuple[str, int | None, int | None], Any]"; expected type "tuple[str, int | None, int | None]"  [index]
nbformat/validator.py:96: error: Invalid index type "tuple[Any, Any, Any, Any]" for "dict[tuple[str, int | None, int | None], Any]"; expected type "tuple[str, int | None, int | None]"  [index]
```

This surfaced as a `Test Lint` CI failure on #436, unrelated to that PR's diff.

## Fix
Widen the annotation to `dict[tuple[str, int | None, int | None, bool], Any]` to match the actual key shape. No behavior change.

## Test plan
- [x] `mypy nbformat/validator.py --strict ...` passes clean
- [x] `python -m pytest -q` passes (191 passed, 2 skipped)
- [x] `ruff check` / `ruff format --check` pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEdA4nuzbhJtNkj8qdSsRq)_