### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autoupdate_schedule: monthly
   autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -65,7 +66,7 @@ repos:
           ["jsonschema>=2.6", "traitlets>=5.13", "jupyter_core>5.4"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.1
     hooks:
       - id: ruff-check
         types_or: [python, jupyter]
@@ -76,7 +77,7 @@ repos:
         types_or: [python, jupyter]
 
   - repo: https://github.com/scientific-python/cookie
-    rev: "2025.10.01"
+    rev: "2026.06.18"
     hooks:
       - id: sp-repo-review
         additional_dependencies: ["repo-review[cli]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,26 @@ test = [
     "packaging"
 ]
 
+# These mirror the "docs" and "test" extras above, which are kept for
+# backwards compatibility (`pip install nbformat[test]`) and are what the
+# hatch environments below consume via `features`.
+[dependency-groups]
+docs = [
+    "myst_parser",
+    "pydata_sphinx_theme",
+    "sphinx",
+    "sphinxcontrib_github_alt",
+    "sphinxcontrib-spelling",
+    "intersphinx_registry",
+]
+test = [
+    "testpath",
+    "pytest",
+    "pre-commit",
+    "packaging",
+]
+dev = [{ include-group = "test" }]
+
 [project.scripts]
 jupyter-trust = "nbformat.sign:TrustNotebookApp.launch_instance"
 
@@ -107,6 +127,7 @@ test = "pre-commit run --all-files --hook-stage manual mypy"
 [tool.pytest.ini_options]
 minversion = "6.0"
 xfail_strict = true
+log_level = "info"
 log_cli_level = "info"
 addopts = [
   "-ra", "--durations=10", "--color=yes", "--doctest-modules",


### PR DESCRIPTION
Ran `pre-commit autoupdate` and fixed the resulting failures.

## Hook updates

- `astral-sh/ruff-pre-commit`: `v0.16.0` → `v0.16.1`
- `scientific-python/cookie`: `2025.10.01` → `2026.06.18`

All other repos were already up to date. `ruff-check` / `ruff-format` produced no changes.

## Fixes for the new `sp-repo-review` checks

The newer cookie release added three checks that failed:

- **PC902** (custom pre-commit.ci autofix message) — added `autofix_commit_msg: "style: pre-commit fixes"` next to the existing `autoupdate_commit_msg`.
- **PP304** (set the pytest log level) — added `log_level = "info"` to `[tool.pytest.ini_options]`, alongside the existing `log_cli_level`.
- **PP006** (define a `dev` dependency group) — added a `[dependency-groups]` table with `docs`, `test` and `dev = [{ include-group = "test" }]`.

On PP006: the group entries mirror the existing `[project.optional-dependencies]` rather than replacing them. The extras are kept so `pip install nbformat[test]` keeps working and so the `hatch` environments (`features = ["test"]`, `features = ["docs"]`), which CI drives, are unaffected. Hatchling rejects `include-group` inside `project.optional-dependencies`, so the lists cannot be deduplicated — they will need to be kept in sync by hand. Happy to drop this hunk and add `PP006` to `[tool.repo-review] ignore` instead if you'd prefer not to carry the duplication.

## Verification

- `pre-commit run --all-files` passes.
- `pytest` passes: 193 passed, 2 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7mgZu8SxpxuwngHqDdtsY)_