### PR TITLE
Remove deprecated kwargs from validate() function

### DIFF
--- a/nbformat/validator.py
+++ b/nbformat/validator.py
@@ -6,12 +6,10 @@ from __future__ import annotations
 
 import json
 import pprint
-import time
 import warnings
 from copy import deepcopy
 from itertools import chain
 from pathlib import Path
-from textwrap import dedent
 from typing import Any
 
 from ._imports import import_item
@@ -21,7 +19,6 @@ from .reader import get_version
 from .warnings import DuplicateCellId, MissingIDFieldWarning
 
 validators: dict[tuple[str, int | None, int | None, bool], Any] = {}
-_deprecated = object()
 
 
 __all__ = [
@@ -388,30 +385,6 @@ def _normalize(
     return changes, nbdict
 
 
-# Deprecated since 2023 and security issue start to annoy people, so passing the
-# deprecated kwargs of `validate` costs the caller this many seconds.
-# Regularly bump this by 1 sec.
-_DEPRECATION_PENALTY_SECONDS = 3
-
-
-def _dep_warn(field):
-    time.sleep(_DEPRECATION_PENALTY_SECONDS)
-
-    warnings.warn(
-        dedent(
-            f"""`{field}` kwargs of validate has been deprecated for security
-        reasons, and will be removed soon.
-
-        Please explicitly use the `n_changes, new_notebook = nbformat.validator.normalize(old_notebook, ...)` if you wish to
-        normalise your notebook. `normalize` is available since nbformat 5.5.0
-
-        """
-        ),
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
-
 def validate(
     nbdict: Any = None,
     ref: str | None = None,
@@ -419,8 +392,6 @@ def validate(
     version_minor: int | None = None,
     relax_add_props: bool = False,
     nbjson: Any = None,
-    repair_duplicate_cell_ids: bool = _deprecated,  # type: ignore[assignment]
-    strip_invalid_metadata: bool = _deprecated,  # type: ignore[assignment]
 ) -> None:
     """Checks whether the given notebook dict-like object
     conforms to the relevant notebook format schema.
@@ -438,10 +409,6 @@ def validate(
         Whether to allow extra properties in the JSON schema validating the notebook.
         When True, all known fields are validated, but unknown fields are ignored.
     nbjson
-    repair_duplicate_cell_ids : bool
-        Deprecated since 5.5.0 - will be removed in the future.
-    strip_invalid_metadata : bool
-        Deprecated since 5.5.0 - will be removed in the future.
 
     Returns
     -------
@@ -453,22 +420,8 @@ def validate(
 
     Notes
     -----
-    Prior to Nbformat 5.5.0 the `validate` and `isvalid` method would silently
-    try to fix invalid notebook and mutate arguments. This behavior is deprecated
-    and will be removed in a near future.
-
     Please explicitly call `normalize` if you need to normalize notebooks.
     """
-    if strip_invalid_metadata is _deprecated:
-        strip_invalid_metadata = False
-    else:
-        _dep_warn("strip_invalid_metadata")
-
-    if repair_duplicate_cell_ids is _deprecated:
-        repair_duplicate_cell_ids = True
-    else:
-        _dep_warn("repair_duplicate_cell_ids")
-
     # backwards compatibility for nbjson argument
     if nbdict is not None:
         pass
@@ -478,15 +431,7 @@ def validate(
         msg = "validate() missing 1 required argument: 'nbdict'"
         raise TypeError(msg)
 
-    _validate(
-        nbdict,
-        ref,
-        version,
-        version_minor,
-        relax_add_props,
-        repair_duplicate_cell_ids=repair_duplicate_cell_ids,
-        strip_invalid_metadata=strip_invalid_metadata,
-    )
+    _validate(nbdict, ref, version, version_minor, relax_add_props)
 
 
 def _validate(
@@ -499,11 +444,11 @@ def _validate(
     repair_duplicate_cell_ids: bool = True,
     strip_invalid_metadata: bool = False,
 ) -> None:
-    """Validate a notebook, bypassing the deprecated-kwarg handling of `validate`.
+    """Validate a notebook, with explicit control over normalization behavior.
 
-    `validate` deliberately penalises callers that pass `repair_duplicate_cell_ids`
-    or `strip_invalid_metadata` (see `_dep_warn`). Internal callers need to set those
-    explicitly without paying that penalty, so they use this helper instead.
+    Internal callers (`isvalid`, `normalize`) use this helper to set
+    `repair_duplicate_cell_ids` and `strip_invalid_metadata` explicitly; the
+    public `validate` always uses the defaults.
     """
     assert isinstance(ref, str) or ref is None
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -15,7 +15,7 @@ from jsonschema import ValidationError
 import nbformat
 from nbformat import read
 from nbformat.json_compat import VALIDATORS
-from nbformat.validator import get_validator, isvalid, iter_validate, validate
+from nbformat.validator import get_validator, isvalid, iter_validate, normalize, validate
 from nbformat.warnings import DuplicateCellId, MissingIDFieldWarning
 
 from .base import TestsBase
@@ -44,16 +44,6 @@ def restore_validator_cache():
     yield
     nbformat.validator.validators.clear()
     nbformat.validator.validators.update(saved)
-
-
-@pytest.fixture
-def no_deprecation_penalty(monkeypatch):
-    """Skip the sleep that `validate` inflicts on callers of its deprecated kwargs.
-
-    The warning itself is what these tests assert on; the sleep is only there to
-    annoy downstream users into migrating, and paying it serves no purpose in CI.
-    """
-    monkeypatch.setattr(nbformat.validator, "_DEPRECATION_PENALTY_SECONDS", 0)
 
 
 # Helpers
@@ -311,22 +301,16 @@ def test_fallback_validator_with_iter_errors_using_ref(recwarn):
     assert len(recwarn) == 0
 
 
-def test_non_unique_cell_ids(no_deprecation_penalty):
+def test_non_unique_cell_ids():
     """Test than a non-unique cell id does not pass validation"""
     with TestsBase.fopen("invalid_unique_cell_id.ipynb", "r") as f:
         # Avoids validate call from `.read`
         nb = nbformat.from_dict(json.load(f))
-    with (
-        pytest.raises(ValidationError),
-        pytest.warns(DeprecationWarning, match="`repair_duplicate_cell_ids` kwargs of validate"),
-    ):
-        validate(nb, repair_duplicate_cell_ids=False)
+    with pytest.raises(ValidationError):
+        nbformat.validator._validate(nb, repair_duplicate_cell_ids=False)
     # try again to verify that we didn't modify the content
-    with (
-        pytest.raises(ValidationError),
-        pytest.warns(DeprecationWarning, match="`repair_duplicate_cell_ids` kwargs of validate"),
-    ):
-        validate(nb, repair_duplicate_cell_ids=False)
+    with pytest.raises(ValidationError):
+        nbformat.validator._validate(nb, repair_duplicate_cell_ids=False)
 
 
 def test_repair_non_unique_cell_ids():
@@ -341,23 +325,17 @@ def test_repair_non_unique_cell_ids():
 
 
 @pytest.mark.filterwarnings("ignore::nbformat.warnings.MissingIDFieldWarning")
-def test_no_cell_ids(no_deprecation_penalty):
+def test_no_cell_ids():
     """Test that a cell without a cell ID does not pass validation"""
 
     with TestsBase.fopen("v4_5_no_cell_id.ipynb", "r") as f:
         # Avoids validate call from `.read`
         nb = nbformat.from_dict(json.load(f))
-    with (
-        pytest.raises(ValidationError),
-        pytest.warns(DeprecationWarning, match="`repair_duplicate_cell_ids` kwargs of validate"),
-    ):
-        validate(nb, repair_duplicate_cell_ids=False)
+    with pytest.raises(ValidationError):
+        nbformat.validator._validate(nb, repair_duplicate_cell_ids=False)
     # try again to verify that we didn't modify the content
-    with (
-        pytest.raises(ValidationError),
-        pytest.warns(DeprecationWarning, match="`repair_duplicate_cell_ids` kwargs of validate"),
-    ):
-        validate(nb, repair_duplicate_cell_ids=False)
+    with pytest.raises(ValidationError):
+        nbformat.validator._validate(nb, repair_duplicate_cell_ids=False)
 
 
 @pytest.mark.filterwarnings("ignore::nbformat.warnings.MissingIDFieldWarning")
@@ -397,15 +375,11 @@ def test_notebook_invalid_without_main_version():
     pass
 
 
-def test_strip_invalid_metadata(no_deprecation_penalty):
+def test_strip_invalid_metadata():
     with TestsBase.fopen("v4_5_invalid_metadata.ipynb", "r") as f:
         nb = nbformat.from_dict(json.load(f))
     assert not isvalid(nb)
-    with pytest.warns(
-        DeprecationWarning,
-        match="`strip_invalid_metadata` kwargs of validate has been deprecated for security",
-    ):
-        validate(nb, strip_invalid_metadata=True)
+    _changes, nb = normalize(nb, strip_invalid_metadata=True)
     assert isvalid(nb)
 
 


### PR DESCRIPTION
## Summary
This PR removes the deprecated `repair_duplicate_cell_ids` and `strip_invalid_metadata` parameters from the public `validate()` function, along with the associated deprecation warning infrastructure that included a deliberate sleep penalty.

## Key Changes
- **Removed deprecated parameters** from `validate()`: `repair_duplicate_cell_ids` and `strip_invalid_metadata` are no longer accepted by the public API
- **Removed deprecation penalty mechanism**: Deleted the `_DEPRECATION_PENALTY_SECONDS` constant and `_dep_warn()` function that imposed a 3-second sleep on callers using deprecated kwargs
- **Removed unused imports**: Cleaned up `time` and `textwrap.dedent` imports that were only used for the deprecation warning
- **Removed sentinel object**: Deleted the `_deprecated` sentinel object that was used to detect when deprecated kwargs were passed
- **Updated `_validate()` docstring**: Changed from explaining the deprecation penalty bypass to clarifying that it's an internal helper with explicit normalization control
- **Updated test suite**: 
  - Removed `no_deprecation_penalty` fixture that was skipping the sleep in tests
  - Updated tests to call `_validate()` directly instead of `validate()` when testing the deprecated behavior
  - Updated `test_strip_invalid_metadata()` to use `normalize()` instead of `validate()` with deprecated kwargs

## Implementation Details
The `_validate()` internal function retains the `repair_duplicate_cell_ids` and `strip_invalid_metadata` parameters with their default values, allowing internal callers like `normalize()` and `isvalid()` to control normalization behavior. The public `validate()` function now always uses the defaults, simplifying the API and removing the security-motivated deprecation penalty.

https://claude.ai/code/session_01AL9GEKqdjR8Ko1WH16cQcH