### PR TITLE
Allow NotebookNotary context manager reuse

### DIFF
--- a/nbformat/sign.py
+++ b/nbformat/sign.py
@@ -459,6 +459,8 @@ class NotebookNotary(LoggingConfigurable):
         """Initialize the notary."""
         super().__init__(**kwargs)
         self.store = self.store_factory()
+        self._context_depth = 0
+        self._store_closed = False
         self._used_as_context_manager = False
         self._warned_not_context_manager = False
 
@@ -468,16 +470,24 @@ class NotebookNotary(LoggingConfigurable):
         Should be called when the notary is no longer needed, to release
         any resources (e.g. database connections) held by the store.
         """
-        self.store.close()
+        if not self._store_closed:
+            self.store.close()
+            self._store_closed = True
 
     def __enter__(self) -> NotebookNotaryContext:
         """Enter the notary's context, marking it as used within a `with` block."""
+        if self._store_closed:
+            self.store = self.store_factory()
+            self._store_closed = False
+        self._context_depth += 1
         self._used_as_context_manager = True
         return self
 
     def __exit__(self, *exc_info):
         """Exit the notary's context, closing its signature store."""
-        self.close()
+        self._context_depth = max(0, self._context_depth - 1)
+        if self._context_depth == 0:
+            self.close()
 
     def _warn_if_not_context_manager(self):
         """Warn once if the store is accessed without using this notary as a context manager.

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -84,6 +84,23 @@ class TestNotary(TestsBase):
                 notary.sign(self.nb)
                 self.assertTrue(notary.check_signature(self.nb))
 
+    def test_context_manager_can_be_reused(self):
+        db_file = os.path.join(self.data_dir, "reusable.db")
+        notary = sign.NotebookNotary(db_file=db_file, secret=b"secret")
+
+        with notary:
+            notary.sign(self.nb)
+
+        with notary:
+            self.assertTrue(notary.check_signature(self.nb))
+
+    def test_context_manager_can_be_nested(self):
+        with self.notary:
+            self.notary.store.store_signature("digest", "sha256")
+            with self.notary:
+                self.assertTrue(self.notary.store.check_signature("digest", "sha256"))
+            self.assertTrue(self.notary.store.check_signature("digest", "sha256"))
+
     def test_algorithms(self):
         last_sig = ""
         for algo in sign.algorithms:


### PR DESCRIPTION
Fixes #454

### Summary
- reopen the signature store when a `NotebookNotary` is entered again after it has closed
- keep nested context-manager entries open until the outermost context exits
- add regression coverage for sequential reuse and nested contexts

### Validation
- `uv run --extra test pytest -q` (195 passed, 2 skipped)
- `uv run --extra test ruff check nbformat/sign.py tests/test_sign.py`
- `uv run --extra test ruff format --check nbformat/sign.py tests/test_sign.py`
- `uv run --extra test pre-commit run ruff-check --files nbformat/sign.py tests/test_sign.py`
- `uv run --extra test pre-commit run ruff-format --files nbformat/sign.py tests/test_sign.py`
- `git diff --check`

The full pre-commit invocation was also attempted; its Prettier environment was blocked by the local npm `EALLOWGIT` policy.

Prepared with AI assistance; I reviewed the implementation and validation output.