### PR TITLE
Try to skip publishing to NPM to be able to publish a patch version on PYPI

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Finalize Release
         id: finalize-release
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,3 +253,11 @@ ignore = ["GH102"]
 
 [tool.codespell]
 skip = "*.ipynb"
+
+[tool.jupyter-releaser]
+# The `nbformat-schema` npm package is no longer published from CI (no npm
+# credentials are configured for this repo). Skipping `build-npm` means no
+# `*.tgz` ends up in the dist folder, so `publish-assets` never invokes
+# `npm publish`; `check-npm` is skipped since it only checks that tarball.
+# Pass `--force` (or remove these entries) if npm publishing is restored.
+skip = ["build-npm", "check-npm"]


### PR DESCRIPTION
Necessary if we want to publish with trusted release and don't get some of the existing maintainer of npm in set the token